### PR TITLE
feat: add provider-agnostic oauth core foundation

### DIFF
--- a/prisma/migrations/20260425103500_oauth_core_foundation/migration.sql
+++ b/prisma/migrations/20260425103500_oauth_core_foundation/migration.sql
@@ -1,0 +1,64 @@
+-- CreateTable
+CREATE TABLE "IntegrationConnection" (
+    "id" TEXT NOT NULL,
+    "provider" TEXT NOT NULL,
+    "ownerKey" TEXT NOT NULL DEFAULT 'global',
+    "externalAccountId" TEXT,
+    "clientId" TEXT,
+    "accessTokenEncrypted" TEXT,
+    "refreshTokenEncrypted" TEXT NOT NULL,
+    "tokenExpiresAt" TIMESTAMP(3),
+    "scopes" TEXT[],
+    "metadata" JSONB,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "IntegrationConnection_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "OAuthState" (
+    "id" TEXT NOT NULL,
+    "provider" TEXT NOT NULL,
+    "state" TEXT NOT NULL,
+    "codeVerifier" TEXT,
+    "redirectPath" TEXT,
+    "clientId" TEXT,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "consumedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "OAuthState_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "IntegrationWebhookEvent" (
+    "id" TEXT NOT NULL,
+    "provider" TEXT NOT NULL,
+    "eventExternalId" TEXT NOT NULL,
+    "eventType" TEXT,
+    "payload" JSONB,
+    "processedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "IntegrationWebhookEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "IntegrationConnection_provider_ownerKey_key" ON "IntegrationConnection"("provider", "ownerKey");
+
+-- CreateIndex
+CREATE INDEX "IntegrationConnection_provider_isActive_idx" ON "IntegrationConnection"("provider", "isActive");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "OAuthState_state_key" ON "OAuthState"("state");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "IntegrationWebhookEvent_provider_eventExternalId_key" ON "IntegrationWebhookEvent"("provider", "eventExternalId");
+
+-- CreateIndex
+CREATE INDEX "IntegrationWebhookEvent_provider_createdAt_idx" ON "IntegrationWebhookEvent"("provider", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "IntegrationConnection" ADD CONSTRAINT "IntegrationConnection_clientId_fkey" FOREIGN KEY ("clientId") REFERENCES "Client"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,6 +24,7 @@ model Client {
   blogPosts    BlogPost[]
   availabilityRules      AvailabilityRule[]
   availabilityExceptions AvailabilityException[]
+  integrationConnections IntegrationConnection[]
 }
 
 model Service {
@@ -123,4 +124,50 @@ model ReminderJob {
 
   @@index([sendAt, status])
   @@index([appointmentId, reminderType])
+}
+
+model IntegrationConnection {
+  id                   String   @id @default(uuid())
+  provider             String
+  ownerKey             String   @default("global")
+  externalAccountId    String?
+  clientId             String?
+  accessTokenEncrypted String?
+  refreshTokenEncrypted String
+  tokenExpiresAt       DateTime?
+  scopes               String[]
+  metadata             Json?
+  isActive             Boolean  @default(true)
+  createdAt            DateTime @default(now())
+  updatedAt            DateTime @updatedAt
+
+  client Client? @relation(fields: [clientId], references: [id], onDelete: Cascade)
+
+  @@unique([provider, ownerKey])
+  @@index([provider, isActive])
+}
+
+model OAuthState {
+  id           String   @id @default(uuid())
+  provider     String
+  state        String   @unique
+  codeVerifier String?
+  redirectPath String?
+  clientId     String?
+  expiresAt    DateTime
+  consumedAt   DateTime?
+  createdAt    DateTime @default(now())
+}
+
+model IntegrationWebhookEvent {
+  id              String   @id @default(uuid())
+  provider        String
+  eventExternalId String
+  eventType       String?
+  payload         Json?
+  processedAt     DateTime?
+  createdAt       DateTime @default(now())
+
+  @@unique([provider, eventExternalId])
+  @@index([provider, createdAt])
 }

--- a/src/__tests__/oauth.routes.test.ts
+++ b/src/__tests__/oauth.routes.test.ts
@@ -1,0 +1,52 @@
+import request from 'supertest';
+import { app } from '../index';
+import '../__tests__/setup';
+
+if (!process.env.ADMIN_KEY) {
+  process.env.ADMIN_KEY = 'test-admin-key';
+}
+
+describe('OAuth Routes', () => {
+  describe('POST /api/oauth/:provider/authorize', () => {
+    it('should require admin authentication', async () => {
+      await request(app).post('/api/oauth/google_calendar/authorize').expect(401);
+    });
+
+    it('should reject unsupported provider', async () => {
+      const response = await request(app)
+        .post('/api/oauth/not-a-provider/authorize')
+        .set('x-admin-key', process.env.ADMIN_KEY || '')
+        .expect(400);
+
+      expect(response.body.error).toBe('Unsupported OAuth provider');
+    });
+  });
+
+  describe('GET /api/oauth/callback/:provider', () => {
+    it('should reject unsupported provider', async () => {
+      const response = await request(app)
+        .get('/api/oauth/callback/not-a-provider')
+        .query({ code: 'abc', state: 'def' })
+        .expect(400);
+
+      expect(response.body.error).toBe('Unsupported OAuth provider');
+    });
+
+    it('should require code and state parameters', async () => {
+      const response = await request(app).get('/api/oauth/callback/google_calendar').expect(400);
+      expect(response.body.error).toBe('Missing OAuth callback parameters');
+    });
+  });
+
+  describe('GET /api/oauth/:provider/status', () => {
+    it('should require admin authentication', async () => {
+      await request(app).get('/api/oauth/google_calendar/status').expect(401);
+    });
+  });
+
+  describe('DELETE /api/oauth/:provider/connection', () => {
+    it('should require admin authentication', async () => {
+      await request(app).delete('/api/oauth/google_calendar/connection').expect(401);
+    });
+  });
+});

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,13 +1,31 @@
 import { Request, Response, NextFunction } from 'express';
 import dotenv from 'dotenv';
+import crypto from 'crypto';
 
 dotenv.config();
 
 // Simple admin authentication middleware
 export const adminAuth = (req: Request, res: Response, next: NextFunction): void => {
-  const adminKey = req.headers['x-admin-key'];
+  const headerKey = req.headers['x-admin-key'];
+  const authHeader = req.headers.authorization;
+  const bearerKey =
+    typeof authHeader === 'string' && authHeader.startsWith('Bearer ')
+      ? authHeader.slice('Bearer '.length)
+      : undefined;
+  const provided = typeof headerKey === 'string' ? headerKey : bearerKey;
+  const expected = process.env.ADMIN_KEY;
 
-  if (!adminKey || adminKey !== process.env.ADMIN_KEY) {
+  if (!provided || !expected) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+
+  const providedBuffer = Buffer.from(provided);
+  const expectedBuffer = Buffer.from(expected);
+  if (
+    providedBuffer.length !== expectedBuffer.length ||
+    !crypto.timingSafeEqual(providedBuffer, expectedBuffer)
+  ) {
     res.status(401).json({ error: 'Unauthorized' });
     return;
   }

--- a/src/routes/appointment.routes.ts
+++ b/src/routes/appointment.routes.ts
@@ -26,6 +26,7 @@ import {
 } from '../services/scheduling.service';
 import { scheduleAppointmentReminder, cancelAppointmentReminders } from '../services/reminder.service';
 import { buildGoogleCalendarEventPayload } from '../services/calendar.service';
+import { appointmentLimiter } from '../middleware/rateLimit';
 
 const appointmentRouter = express.Router();
 const prisma = new PrismaClient();
@@ -79,7 +80,7 @@ const hasSchedulingConflict = async (
 };
 
 // Create a new appointment
-appointmentRouter.post('/', validateAppointment, async (req: Request, res: Response) => {
+appointmentRouter.post('/', appointmentLimiter, validateAppointment, async (req: Request, res: Response) => {
   try {
     const {
       clientFirstName,

--- a/src/routes/client.routes.ts
+++ b/src/routes/client.routes.ts
@@ -1,13 +1,12 @@
 import express, { Request, Response, Router } from 'express';
 import { PrismaClient } from '@prisma/client';
 import { validateClient } from '../validations/client.validation';
-import { adminAuth } from '../middleware/auth';
 
 const clientRouter: Router = express.Router();
 const prisma = new PrismaClient();
 
 // Get all clients (admin)
-clientRouter.get('/', adminAuth, async (_req: Request, res: Response): Promise<void> => {
+clientRouter.get('/', async (_req: Request, res: Response): Promise<void> => {
   try {
     const clients = await prisma.client.findMany();
     res.json(clients);
@@ -17,7 +16,7 @@ clientRouter.get('/', adminAuth, async (_req: Request, res: Response): Promise<v
 });
 
 // Get client by ID (admin)
-clientRouter.get('/:id', adminAuth, async (req: Request, res: Response): Promise<void> => {
+clientRouter.get('/:id', async (req: Request, res: Response): Promise<void> => {
   try {
     const client = await prisma.client.findUnique({
       where: { id: req.params.id }
@@ -33,7 +32,7 @@ clientRouter.get('/:id', adminAuth, async (req: Request, res: Response): Promise
 });
 
 // Create new client (admin)
-clientRouter.post('/', adminAuth, validateClient, async (req: Request, res: Response): Promise<void> => {
+clientRouter.post('/', validateClient, async (req: Request, res: Response): Promise<void> => {
   try {
     const client = await prisma.client.create({
       data: req.body
@@ -45,7 +44,7 @@ clientRouter.post('/', adminAuth, validateClient, async (req: Request, res: Resp
 });
 
 // Update client (admin)
-clientRouter.put('/:id', adminAuth, validateClient, async (req: Request, res: Response): Promise<void> => {
+clientRouter.put('/:id', validateClient, async (req: Request, res: Response): Promise<void> => {
   try {
     const client = await prisma.client.update({
       where: { id: req.params.id },
@@ -58,7 +57,7 @@ clientRouter.put('/:id', adminAuth, validateClient, async (req: Request, res: Re
 });
 
 // Delete client (admin)
-clientRouter.delete('/:id', adminAuth, async (req: Request, res: Response): Promise<void> => {
+clientRouter.delete('/:id', async (req: Request, res: Response): Promise<void> => {
   try {
     await prisma.client.delete({
       where: { id: req.params.id }

--- a/src/routes/email.routes.ts
+++ b/src/routes/email.routes.ts
@@ -1,13 +1,12 @@
 import express, { Request, Response } from 'express';
 import { sendEmail, verifyEmailConfig } from '../services/email.service';
-import { adminAuth } from '../middleware/auth';
 import { dispatchDueAppointmentReminders } from '../services/reminder.service';
 
 const emailRouter = express.Router();
 
 // Verification endpoint - sends a test email
 // Protected by admin auth to prevent abuse
-emailRouter.post('/verify', adminAuth, async (req: Request, res: Response): Promise<void> => {
+emailRouter.post('/verify', async (req: Request, res: Response): Promise<void> => {
   try {
     const { email } = req.body;
 
@@ -86,7 +85,7 @@ emailRouter.post('/verify', adminAuth, async (req: Request, res: Response): Prom
 });
 
 // Email configuration verification endpoint
-emailRouter.get('/config/verify', adminAuth, async (_req: Request, res: Response): Promise<void> => {
+emailRouter.get('/config/verify', async (_req: Request, res: Response): Promise<void> => {
   try {
     const isValid = await verifyEmailConfig();
 
@@ -123,7 +122,7 @@ emailRouter.get('/config/verify', adminAuth, async (_req: Request, res: Response
 });
 
 // Dispatch due reminder jobs (admin-triggered; intended for cron/automation)
-emailRouter.post('/reminders/dispatch', adminAuth, async (_req: Request, res: Response): Promise<void> => {
+emailRouter.post('/reminders/dispatch', async (_req: Request, res: Response): Promise<void> => {
   try {
     const result = await dispatchDueAppointmentReminders();
     res.json({

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -9,6 +9,7 @@ import blogPostRouter from './blogPost.routes';
 import { adminAuth } from '../middleware/auth';
 import contactRouter from "./contact.routes";
 import emailRouter from "./email.routes";
+import oauthRouter from './oauth.routes';
 
 const router = express.Router();
 
@@ -18,12 +19,13 @@ router.use('/services', serviceRouter);
 router.use('/testimonials', testimonialRouter);
 router.use('/blog', blogPostRouter);
 router.use('/contact', contactRouter);
+router.use('/oauth', oauthRouter);
 
 // Admin routes (require admin authentication)
 router.use('/admin/clients', adminAuth, clientRouter);
 router.use('/admin/services', adminAuth, serviceRouter);
 router.use('/admin/testimonials', adminAuth, testimonialRouter);
 router.use('/admin/blog-posts', adminAuth, blogPostRouter);
-router.use('/admin/email', emailRouter);
+router.use('/admin/email', adminAuth, emailRouter);
 
 export default router;

--- a/src/routes/oauth.routes.ts
+++ b/src/routes/oauth.routes.ts
@@ -1,0 +1,111 @@
+import express, { Request, Response } from 'express';
+import { adminAuth } from '../middleware/auth';
+import { authLimiter } from '../middleware/rateLimit';
+import { isSupportedOAuthProvider } from '../services/oauth/oauth.providers';
+import {
+  completeOAuthAuthorization,
+  createOAuthAuthorization,
+  disconnectOAuthProvider,
+  getOAuthConnectionStatus,
+} from '../services/oauth/oauth.service';
+
+const oauthRouter = express.Router();
+
+oauthRouter.post('/:provider/authorize', authLimiter, adminAuth, async (req: Request, res: Response): Promise<void> => {
+  try {
+    const provider = req.params.provider;
+    if (!isSupportedOAuthProvider(provider)) {
+      res.status(400).json({ error: 'Unsupported OAuth provider' });
+      return;
+    }
+
+    const { redirectPath, ownerKey, clientId } = req.body ?? {};
+    const response = await createOAuthAuthorization(provider, {
+      redirectPath: typeof redirectPath === 'string' ? redirectPath : undefined,
+      ownerKey: typeof ownerKey === 'string' ? ownerKey : undefined,
+      clientId: typeof clientId === 'string' ? clientId : undefined,
+    });
+    res.json(response);
+  } catch (error) {
+    console.error('Error creating OAuth authorization URL:', error);
+    res.status(500).json({ error: error instanceof Error ? error.message : 'Failed to create OAuth authorization URL' });
+  }
+});
+
+oauthRouter.get('/callback/:provider', authLimiter, async (req: Request, res: Response): Promise<void> => {
+  try {
+    const provider = req.params.provider;
+    if (!isSupportedOAuthProvider(provider)) {
+      res.status(400).json({ error: 'Unsupported OAuth provider' });
+      return;
+    }
+
+    const code = typeof req.query.code === 'string' ? req.query.code : null;
+    const state = typeof req.query.state === 'string' ? req.query.state : null;
+    const ownerKey = typeof req.query.ownerKey === 'string' ? req.query.ownerKey : undefined;
+    if (!code || !state) {
+      res.status(400).json({ error: 'Missing OAuth callback parameters' });
+      return;
+    }
+
+    const result = await completeOAuthAuthorization({
+      provider,
+      code,
+      state,
+      ownerKey,
+    });
+
+    if (result.redirectPath) {
+      const target = new URL(result.redirectPath, process.env.FRONTEND_URL || 'http://localhost:3000');
+      target.searchParams.set('provider', result.provider);
+      target.searchParams.set('connected', 'true');
+      res.redirect(target.toString());
+      return;
+    }
+
+    res.json({
+      status: 'connected',
+      provider: result.provider,
+      ownerKey: result.ownerKey,
+    });
+  } catch (error) {
+    console.error('OAuth callback error:', error);
+    res.status(400).json({ error: error instanceof Error ? error.message : 'OAuth callback failed' });
+  }
+});
+
+oauthRouter.get('/:provider/status', adminAuth, async (req: Request, res: Response): Promise<void> => {
+  try {
+    const provider = req.params.provider;
+    if (!isSupportedOAuthProvider(provider)) {
+      res.status(400).json({ error: 'Unsupported OAuth provider' });
+      return;
+    }
+
+    const ownerKey = typeof req.query.ownerKey === 'string' ? req.query.ownerKey : undefined;
+    const status = await getOAuthConnectionStatus(provider, ownerKey);
+    res.json({ provider, ownerKey: ownerKey || 'global', ...status });
+  } catch (error) {
+    console.error('Error fetching OAuth connection status:', error);
+    res.status(500).json({ error: 'Failed to fetch OAuth connection status' });
+  }
+});
+
+oauthRouter.delete('/:provider/connection', adminAuth, async (req: Request, res: Response): Promise<void> => {
+  try {
+    const provider = req.params.provider;
+    if (!isSupportedOAuthProvider(provider)) {
+      res.status(400).json({ error: 'Unsupported OAuth provider' });
+      return;
+    }
+
+    const ownerKey = typeof req.query.ownerKey === 'string' ? req.query.ownerKey : undefined;
+    await disconnectOAuthProvider(provider, ownerKey);
+    res.status(204).send();
+  } catch (error) {
+    console.error('Error disconnecting OAuth provider:', error);
+    res.status(500).json({ error: 'Failed to disconnect OAuth provider' });
+  }
+});
+
+export default oauthRouter;

--- a/src/services/oauth/oauth.crypto.ts
+++ b/src/services/oauth/oauth.crypto.ts
@@ -1,0 +1,51 @@
+import crypto from 'crypto';
+
+const ALGO = 'aes-256-gcm';
+
+const getEncryptionKey = (): Buffer => {
+  const key = process.env.INTEGRATION_ENCRYPTION_KEY;
+  if (!key) {
+    throw new Error('Missing required environment variable: INTEGRATION_ENCRYPTION_KEY');
+  }
+
+  const normalized = key.trim();
+  if (normalized.length === 64 && /^[0-9a-fA-F]+$/.test(normalized)) {
+    return Buffer.from(normalized, 'hex');
+  }
+
+  const asBase64 = Buffer.from(normalized, 'base64');
+  if (asBase64.length === 32) {
+    return asBase64;
+  }
+
+  throw new Error(
+    'INTEGRATION_ENCRYPTION_KEY must be 32-byte base64 or 64-char hex.'
+  );
+};
+
+export const encryptSecret = (plaintext: string): string => {
+  const key = getEncryptionKey();
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv(ALGO, key, iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+
+  return `${iv.toString('base64')}.${authTag.toString('base64')}.${ciphertext.toString('base64')}`;
+};
+
+export const decryptSecret = (encoded: string): string => {
+  const [ivB64, tagB64, dataB64] = encoded.split('.');
+  if (!ivB64 || !tagB64 || !dataB64) {
+    throw new Error('Invalid encrypted secret format');
+  }
+
+  const key = getEncryptionKey();
+  const decipher = crypto.createDecipheriv(ALGO, key, Buffer.from(ivB64, 'base64'));
+  decipher.setAuthTag(Buffer.from(tagB64, 'base64'));
+  const plaintext = Buffer.concat([
+    decipher.update(Buffer.from(dataB64, 'base64')),
+    decipher.final(),
+  ]);
+
+  return plaintext.toString('utf8');
+};

--- a/src/services/oauth/oauth.providers.ts
+++ b/src/services/oauth/oauth.providers.ts
@@ -1,0 +1,61 @@
+import { OAuthProvider, OAuthProviderConfig } from './oauth.types';
+
+const getRequiredEnv = (key: string): string => {
+  const value = process.env[key];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${key}`);
+  }
+  return value;
+};
+
+const parseScopes = (value: string | undefined, fallback: string[]): string[] => {
+  if (!value) {
+    return fallback;
+  }
+
+  return value
+    .split(/[,\s]+/)
+    .map((scope) => scope.trim())
+    .filter(Boolean);
+};
+
+export const getOAuthProviderConfig = (provider: OAuthProvider): OAuthProviderConfig => {
+  switch (provider) {
+    case 'google_calendar':
+      return {
+        provider,
+        authorizeUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+        tokenUrl: 'https://oauth2.googleapis.com/token',
+        clientId: getRequiredEnv('GOOGLE_OAUTH_CLIENT_ID'),
+        clientSecret: getRequiredEnv('GOOGLE_OAUTH_CLIENT_SECRET'),
+        redirectUri: getRequiredEnv('GOOGLE_OAUTH_REDIRECT_URI'),
+        scopes: parseScopes(process.env.GOOGLE_OAUTH_SCOPES, [
+          'https://www.googleapis.com/auth/calendar',
+          'https://www.googleapis.com/auth/userinfo.email',
+        ]),
+        accessType: 'offline',
+        prompt: 'consent',
+      };
+    case 'intuit':
+      return {
+        provider,
+        authorizeUrl: process.env.INTUIT_OAUTH_AUTHORIZE_URL || 'https://appcenter.intuit.com/connect/oauth2',
+        tokenUrl: process.env.INTUIT_OAUTH_TOKEN_URL || 'https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer',
+        clientId: getRequiredEnv('INTUIT_OAUTH_CLIENT_ID'),
+        clientSecret: getRequiredEnv('INTUIT_OAUTH_CLIENT_SECRET'),
+        redirectUri: getRequiredEnv('INTUIT_OAUTH_REDIRECT_URI'),
+        scopes: parseScopes(process.env.INTUIT_OAUTH_SCOPES, [
+          'com.intuit.quickbooks.accounting',
+          'com.intuit.quickbooks.payment',
+        ]),
+        usesBasicClientAuth: true,
+      };
+    default: {
+      const exhaustive: never = provider;
+      throw new Error(`Unsupported OAuth provider: ${String(exhaustive)}`);
+    }
+  }
+};
+
+export const isSupportedOAuthProvider = (value: string): value is OAuthProvider =>
+  value === 'google_calendar' || value === 'intuit';

--- a/src/services/oauth/oauth.service.ts
+++ b/src/services/oauth/oauth.service.ts
@@ -1,0 +1,281 @@
+import axios from 'axios';
+import crypto from 'crypto';
+import { Prisma, PrismaClient } from '@prisma/client';
+import { decryptSecret, encryptSecret } from './oauth.crypto';
+import { getOAuthProviderConfig } from './oauth.providers';
+import { OAuthProvider, OAuthTokenResponse } from './oauth.types';
+
+const prisma = new PrismaClient();
+const OAUTH_STATE_TTL_MINUTES = 15;
+const DEFAULT_OWNER_KEY = 'global';
+
+const b64Url = (buf: Buffer): string =>
+  buf
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '');
+
+const createPkceVerifier = (): string => b64Url(crypto.randomBytes(64));
+
+const createPkceChallenge = (verifier: string): string =>
+  b64Url(crypto.createHash('sha256').update(verifier).digest());
+
+const exchangeCode = async (
+  provider: OAuthProvider,
+  code: string,
+  codeVerifier?: string
+): Promise<OAuthTokenResponse> => {
+  const cfg = getOAuthProviderConfig(provider);
+
+  const params = new URLSearchParams();
+  params.set('grant_type', 'authorization_code');
+  params.set('code', code);
+  params.set('redirect_uri', cfg.redirectUri);
+  params.set('client_id', cfg.clientId);
+  if (!cfg.usesBasicClientAuth) {
+    params.set('client_secret', cfg.clientSecret);
+  }
+  if (codeVerifier) {
+    params.set('code_verifier', codeVerifier);
+  }
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/x-www-form-urlencoded',
+  };
+  if (cfg.usesBasicClientAuth) {
+    headers.Authorization = `Basic ${Buffer.from(`${cfg.clientId}:${cfg.clientSecret}`).toString('base64')}`;
+  }
+
+  const response = await axios.post<OAuthTokenResponse>(cfg.tokenUrl, params.toString(), { headers });
+  return response.data;
+};
+
+const refreshToken = async (provider: OAuthProvider, refreshTokenValue: string): Promise<OAuthTokenResponse> => {
+  const cfg = getOAuthProviderConfig(provider);
+
+  const params = new URLSearchParams();
+  params.set('grant_type', 'refresh_token');
+  params.set('refresh_token', refreshTokenValue);
+  params.set('client_id', cfg.clientId);
+  if (!cfg.usesBasicClientAuth) {
+    params.set('client_secret', cfg.clientSecret);
+  }
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/x-www-form-urlencoded',
+  };
+  if (cfg.usesBasicClientAuth) {
+    headers.Authorization = `Basic ${Buffer.from(`${cfg.clientId}:${cfg.clientSecret}`).toString('base64')}`;
+  }
+
+  const response = await axios.post<OAuthTokenResponse>(cfg.tokenUrl, params.toString(), { headers });
+  return response.data;
+};
+
+const getTokenExpiryDate = (seconds?: number): Date | null => {
+  if (!seconds || Number.isNaN(seconds)) {
+    return null;
+  }
+  return new Date(Date.now() + seconds * 1000);
+};
+
+export const createOAuthAuthorization = async (
+  provider: OAuthProvider,
+  options?: { ownerKey?: string; clientId?: string; redirectPath?: string }
+): Promise<{ state: string; authorizationUrl: string }> => {
+  const cfg = getOAuthProviderConfig(provider);
+  const state = b64Url(crypto.randomBytes(32));
+  const codeVerifier = createPkceVerifier();
+  const codeChallenge = createPkceChallenge(codeVerifier);
+
+  await prisma.oAuthState.create({
+    data: {
+      provider,
+      state,
+      codeVerifier,
+      redirectPath: options?.redirectPath ?? null,
+      clientId: options?.clientId ?? null,
+      expiresAt: new Date(Date.now() + OAUTH_STATE_TTL_MINUTES * 60 * 1000),
+    },
+  });
+
+  const params = new URLSearchParams();
+  params.set('response_type', 'code');
+  params.set('client_id', cfg.clientId);
+  params.set('redirect_uri', cfg.redirectUri);
+  params.set('scope', cfg.scopes.join(' '));
+  params.set('state', state);
+  params.set('code_challenge', codeChallenge);
+  params.set('code_challenge_method', 'S256');
+  if (cfg.accessType) {
+    params.set('access_type', cfg.accessType);
+  }
+  if (cfg.prompt) {
+    params.set('prompt', cfg.prompt);
+  }
+
+  return {
+    state,
+    authorizationUrl: `${cfg.authorizeUrl}?${params.toString()}`,
+  };
+};
+
+export const completeOAuthAuthorization = async (params: {
+  provider: OAuthProvider;
+  code: string;
+  state: string;
+  ownerKey?: string;
+}): Promise<{ provider: OAuthProvider; ownerKey: string; redirectPath: string | null }> => {
+  const ownerKey = params.ownerKey ?? DEFAULT_OWNER_KEY;
+
+  const stateRecord = await prisma.oAuthState.findUnique({
+    where: { state: params.state },
+  });
+
+  if (!stateRecord || stateRecord.provider !== params.provider) {
+    throw new Error('Invalid OAuth state');
+  }
+  if (stateRecord.consumedAt) {
+    throw new Error('OAuth state already consumed');
+  }
+  if (stateRecord.expiresAt.getTime() < Date.now()) {
+    throw new Error('OAuth state expired');
+  }
+
+  const tokenResponse = await exchangeCode(params.provider, params.code, stateRecord.codeVerifier ?? undefined);
+  if (!tokenResponse.refresh_token) {
+    throw new Error('Provider did not return a refresh token');
+  }
+  const refreshTokenValue = tokenResponse.refresh_token;
+
+  const scopes = tokenResponse.scope
+    ? tokenResponse.scope.split(/\s+/).filter(Boolean)
+    : getOAuthProviderConfig(params.provider).scopes;
+
+  await prisma.$transaction(async (tx) => {
+    await tx.oAuthState.update({
+      where: { id: stateRecord.id },
+      data: { consumedAt: new Date() },
+    });
+
+    await tx.integrationConnection.upsert({
+      where: {
+        provider_ownerKey: {
+          provider: params.provider,
+          ownerKey,
+        },
+      },
+      update: {
+        clientId: stateRecord.clientId ?? undefined,
+        accessTokenEncrypted: tokenResponse.access_token
+          ? encryptSecret(tokenResponse.access_token)
+          : undefined,
+        refreshTokenEncrypted: encryptSecret(refreshTokenValue),
+        tokenExpiresAt: getTokenExpiryDate(tokenResponse.expires_in),
+        scopes,
+        metadata: tokenResponse.realmId
+          ? { realmId: tokenResponse.realmId }
+          : undefined,
+        isActive: true,
+      },
+      create: {
+        provider: params.provider,
+        ownerKey,
+        clientId: stateRecord.clientId ?? null,
+        accessTokenEncrypted: tokenResponse.access_token
+          ? encryptSecret(tokenResponse.access_token)
+          : null,
+        refreshTokenEncrypted: encryptSecret(refreshTokenValue),
+        tokenExpiresAt: getTokenExpiryDate(tokenResponse.expires_in),
+        scopes,
+        metadata: tokenResponse.realmId ? { realmId: tokenResponse.realmId } : undefined,
+        isActive: true,
+      },
+    });
+  });
+
+  return {
+    provider: params.provider,
+    ownerKey,
+    redirectPath: stateRecord.redirectPath,
+  };
+};
+
+export const getAccessTokenForProvider = async (
+  provider: OAuthProvider,
+  ownerKey: string = DEFAULT_OWNER_KEY
+): Promise<string | null> => {
+  const connection = await prisma.integrationConnection.findUnique({
+    where: { provider_ownerKey: { provider, ownerKey } },
+  });
+
+  if (!connection || !connection.isActive) {
+    return null;
+  }
+
+  const needsRefresh =
+    !connection.accessTokenEncrypted ||
+    (connection.tokenExpiresAt ? connection.tokenExpiresAt.getTime() <= Date.now() + 60_000 : false);
+
+  if (!needsRefresh && connection.accessTokenEncrypted) {
+    return decryptSecret(connection.accessTokenEncrypted);
+  }
+
+  const refreshed = await refreshToken(provider, decryptSecret(connection.refreshTokenEncrypted));
+
+  const updated = await prisma.integrationConnection.update({
+    where: { id: connection.id },
+    data: {
+      accessTokenEncrypted: refreshed.access_token ? encryptSecret(refreshed.access_token) : connection.accessTokenEncrypted,
+      refreshTokenEncrypted: refreshed.refresh_token
+        ? encryptSecret(refreshed.refresh_token)
+        : connection.refreshTokenEncrypted,
+      tokenExpiresAt: getTokenExpiryDate(refreshed.expires_in),
+      scopes: refreshed.scope ? refreshed.scope.split(/\s+/).filter(Boolean) : connection.scopes,
+      metadata: refreshed.realmId
+        ? {
+            ...((connection.metadata as Record<string, unknown> | null) ?? {}),
+            realmId: refreshed.realmId,
+          }
+        : (connection.metadata as Prisma.InputJsonValue | undefined),
+    },
+  });
+
+  return updated.accessTokenEncrypted ? decryptSecret(updated.accessTokenEncrypted) : null;
+};
+
+export const getOAuthConnectionStatus = async (
+  provider: OAuthProvider,
+  ownerKey: string = DEFAULT_OWNER_KEY
+): Promise<{ connected: boolean; expiresAt: string | null; scopes: string[]; updatedAt: string | null }> => {
+  const connection = await prisma.integrationConnection.findUnique({
+    where: { provider_ownerKey: { provider, ownerKey } },
+  });
+  if (!connection || !connection.isActive) {
+    return { connected: false, expiresAt: null, scopes: [], updatedAt: null };
+  }
+
+  return {
+    connected: true,
+    expiresAt: connection.tokenExpiresAt?.toISOString() ?? null,
+    scopes: connection.scopes,
+    updatedAt: connection.updatedAt.toISOString(),
+  };
+};
+
+export const disconnectOAuthProvider = async (
+  provider: OAuthProvider,
+  ownerKey: string = DEFAULT_OWNER_KEY
+): Promise<void> => {
+  await prisma.integrationConnection.updateMany({
+    where: { provider, ownerKey },
+    data: {
+      isActive: false,
+      accessTokenEncrypted: null,
+      refreshTokenEncrypted: encryptSecret(crypto.randomUUID()),
+      tokenExpiresAt: null,
+      metadata: Prisma.JsonNull,
+    },
+  });
+};

--- a/src/services/oauth/oauth.types.ts
+++ b/src/services/oauth/oauth.types.ts
@@ -1,0 +1,24 @@
+export type OAuthProvider = 'google_calendar' | 'intuit';
+
+export interface OAuthProviderConfig {
+  provider: OAuthProvider;
+  authorizeUrl: string;
+  tokenUrl: string;
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
+  scopes: string[];
+  accessType?: 'offline' | 'online';
+  prompt?: string;
+  usesBasicClientAuth?: boolean;
+}
+
+export interface OAuthTokenResponse {
+  access_token: string;
+  refresh_token?: string;
+  expires_in?: number;
+  scope?: string;
+  token_type?: string;
+  realmId?: string;
+  x_refresh_token_expires_in?: number;
+}


### PR DESCRIPTION
## Summary
- Add provider-agnostic OAuth 2.0 core primitives for Google Calendar and Intuit.
- Add encrypted integration token storage, OAuth state handling, and callback lifecycle.
- Standardize auth/rate-limit foundations for upcoming provider integrations.
## Changes
- Added OAuth core services and provider config abstractions.
- Added OAuth routes for authorize/callback/status/disconnect.
- Added Prisma models/migration:
  - `IntegrationConnection`
  - `OAuthState`
  - `IntegrationWebhookEvent`
- Hardened admin auth comparison logic (timing-safe).
- Added initial OAuth route tests.
## Why
This establishes a reusable OAuth base so Google and Intuit integrations don’t duplicate auth logic.
## Test Plan
- `npx tsc --noEmit`
- `npm test -- src/__tests__/oauth.routes.test.ts --runInBand`
- `npm test -- src/__tests__/security.test.ts --runInBand`
