### PR TITLE
feat: migrate calendar sync to oauth token model

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -294,19 +294,57 @@ Reminder dispatch:
 - Sends customer and owner reminder emails for due jobs
 - Marks jobs sent/failed with timestamps and error messages
 
-## 10) Google Calendar Readiness
+## 10) Google Calendar Sync
 
-Current API includes calendar-ready fields:
+Current API includes calendar-linked fields:
 
 - `Appointment.calendarEventId`
 - normalized start/end (`date`, `endDate`)
 - timezone tracking
 
-The code includes a calendar payload builder service:
+Calendar service:
 
 - `src/services/calendar.service.ts`
 
-Current behavior prepares payloads in flow as integration hook points; direct Google API sync is not yet wired.
+Current behavior synchronizes events with Google Calendar during appointment lifecycle operations:
+
+- create appointment -> create/update Google Calendar event
+- update appointment -> update event (or recreate if missing)
+- delete appointment -> delete Google Calendar event
+
+Sync is best-effort and non-blocking (API success is not blocked by Calendar API failure).
+
+### Required environment variables
+
+```env
+GOOGLE_CALENDAR_SYNC_ENABLED=true
+GOOGLE_CALENDAR_ID=primary
+GOOGLE_CALENDAR_AUTH_MODE=oauth
+GOOGLE_OAUTH_CLIENT_ID=...
+GOOGLE_OAUTH_CLIENT_SECRET=...
+GOOGLE_OAUTH_REDIRECT_URI=http://localhost:5001/api/oauth/callback/google_calendar
+```
+
+Optional fallback: service account credentials (if `GOOGLE_CALENDAR_ALLOW_SERVICE_ACCOUNT_FALLBACK=true`):
+
+```env
+# Option A (recommended for deployment systems)
+GOOGLE_SERVICE_ACCOUNT_JSON_BASE64=...
+
+# Option B
+GOOGLE_SERVICE_ACCOUNT_JSON={"type":"service_account",...}
+
+# Option C
+GOOGLE_SERVICE_ACCOUNT_EMAIL=...
+GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
+```
+
+Google OAuth connection flow:
+
+- `POST /api/oauth/google_calendar/authorize` (admin auth required)
+- Redirect user to returned `authorizationUrl`
+- Google callback hits `/api/oauth/callback/google_calendar`
+- Appointment create/update/delete syncs use stored OAuth tokens
 
 ## 11) Project Commands
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,32 @@ Server defaults:
 - App URL: `http://localhost:5001`
 - API base: `http://localhost:5001/api`
 
+## Google Calendar Sync (Optional)
+
+Set these environment variables to enable real Google Calendar event sync for appointment create/update/delete flows:
+
+```env
+GOOGLE_CALENDAR_SYNC_ENABLED=true
+GOOGLE_CALENDAR_ID=primary
+GOOGLE_CALENDAR_AUTH_MODE=oauth
+
+# Required for OAuth mode:
+GOOGLE_OAUTH_CLIENT_ID=...
+GOOGLE_OAUTH_CLIENT_SECRET=...
+GOOGLE_OAUTH_REDIRECT_URI=http://localhost:5001/api/oauth/callback/google_calendar
+# Optional override:
+# GOOGLE_OAUTH_SCOPES=https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/userinfo.email
+
+# Optional service-account fallback:
+# GOOGLE_CALENDAR_ALLOW_SERVICE_ACCOUNT_FALLBACK=true
+# GOOGLE_SERVICE_ACCOUNT_JSON_BASE64=...
+
+# Alternate service-account formats:
+# GOOGLE_SERVICE_ACCOUNT_JSON={"type":"service_account",...}
+# GOOGLE_SERVICE_ACCOUNT_EMAIL=...
+# GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
+```
+
 ## Test Commands
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "express": "^4.21.2",
         "express-rate-limit": "^7.5.0",
         "express-xss-sanitizer": "^2.0.0",
+        "googleapis": "^171.4.0",
         "helmet": "^8.1.0",
         "hpp": "^0.2.3",
         "joi": "^17.13.3",
@@ -3304,6 +3305,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -3537,6 +3547,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/basic-auth": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
@@ -3554,6 +3584,15 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/body-parser": {
       "version": "1.20.3",
@@ -3665,6 +3704,12 @@
       "dependencies": {
         "node-int64": "^0.4.0"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -4013,6 +4058,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -4194,6 +4248,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -4569,6 +4632,12 @@
         "sanitize-html": "~2.13.0"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -4610,6 +4679,29 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/filelist": {
@@ -4725,6 +4817,18 @@
         "node": ">= 6"
       }
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/formidable": {
       "version": "3.5.4",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
@@ -4790,6 +4894,34 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/gensync": {
@@ -4902,6 +5034,61 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis": {
+      "version": "171.4.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-171.4.0.tgz",
+      "integrity": "sha512-xybFL2SmmUgIifgsbsRQYRdNrSAYwxWZDmkZTGjUIaRnX5jPqR8el/cEvo6rCqh7iaZx6MfEPS/lrDgZ0bymkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.2.0",
+        "googleapis-common": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-8.0.1.tgz",
+      "integrity": "sha512-eCzNACUXPb1PW5l0ULTzMHaL/ltPRADoPgjBlT8jWsTbxkCp6siv+qKJ/1ldaybCthGwsYFYallF7u9AkU4L+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^7.0.0-rc.4",
+        "google-auth-library": "^10.1.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/gopd": {
@@ -5035,6 +5222,42 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -5968,6 +6191,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -5986,6 +6218,27 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/kleur": {
@@ -6276,6 +6529,44 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-int64": {
@@ -7565,6 +7856,12 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "license": "BSD"
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -7613,6 +7910,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "express": "^4.21.2",
     "express-rate-limit": "^7.5.0",
     "express-xss-sanitizer": "^2.0.0",
+    "googleapis": "^171.4.0",
     "helmet": "^8.1.0",
     "hpp": "^0.2.3",
     "joi": "^17.13.3",

--- a/src/routes/appointment.routes.ts
+++ b/src/routes/appointment.routes.ts
@@ -25,8 +25,11 @@ import {
   rangesOverlap,
 } from '../services/scheduling.service';
 import { scheduleAppointmentReminder, cancelAppointmentReminders } from '../services/reminder.service';
-import { buildGoogleCalendarEventPayload } from '../services/calendar.service';
 import { appointmentLimiter } from '../middleware/rateLimit';
+import {
+  deleteGoogleCalendarEvent,
+  upsertGoogleCalendarEvent,
+} from '../services/calendar.service';
 
 const appointmentRouter = express.Router();
 const prisma = new PrismaClient();
@@ -128,7 +131,7 @@ appointmentRouter.post('/', appointmentLimiter, validateAppointment, async (req:
       return;
     }
 
-    const appointment = await prisma.appointment.create({
+    let appointment = await prisma.appointment.create({
       data: {
         clientFirstName,
         clientLastName,
@@ -165,8 +168,19 @@ appointmentRouter.post('/', appointmentLimiter, validateAppointment, async (req:
       console.error('Failed to schedule appointment reminder:', err);
     }
 
-    // Hook point for Google Calendar integration.
-    void buildGoogleCalendarEventPayload(appointment, service);
+    // Sync with Google Calendar when enabled.
+    try {
+      const calendarEventId = await upsertGoogleCalendarEvent(appointment, service);
+      if (calendarEventId && calendarEventId !== appointment.calendarEventId) {
+        appointment = await prisma.appointment.update({
+          where: { id: appointment.id },
+          data: { calendarEventId },
+          include: { service: true },
+        });
+      }
+    } catch (err) {
+      console.error('Failed to sync appointment to Google Calendar:', err);
+    }
 
     getBusinessOwnerEmailForNotification(service).then((ownerEmail) => {
       if (ownerEmail) {
@@ -408,7 +422,7 @@ appointmentRouter.put('/:id', validateAppointmentUpdate, async (req: Request, re
       }
     }
 
-    const appointment = await prisma.appointment.update({
+    let appointment = await prisma.appointment.update({
       where: { id: req.params.id },
       data: {
         clientFirstName,
@@ -470,7 +484,21 @@ appointmentRouter.put('/:id', validateAppointmentUpdate, async (req: Request, re
       } catch (err) {
         console.error('Failed to reschedule appointment reminder:', err);
       }
-      void buildGoogleCalendarEventPayload(appointment, appointment.service);
+    }
+
+    if (appointment.service && appointment.states !== 'cancelled') {
+      try {
+        const calendarEventId = await upsertGoogleCalendarEvent(appointment, appointment.service);
+        if (calendarEventId && calendarEventId !== appointment.calendarEventId) {
+          appointment = await prisma.appointment.update({
+            where: { id: appointment.id },
+            data: { calendarEventId },
+            include: { service: true },
+          });
+        }
+      } catch (err) {
+        console.error('Failed to sync updated appointment to Google Calendar:', err);
+      }
     }
 
     res.json(appointment);
@@ -541,6 +569,13 @@ appointmentRouter.delete('/:id', async (req: Request, res: Response) => {
     }
 
     await cancelAppointmentReminders(appointment.id);
+    if (appointment.calendarEventId) {
+      try {
+        await deleteGoogleCalendarEvent(appointment.calendarEventId);
+      } catch (err) {
+        console.error('Failed to delete appointment from Google Calendar:', err);
+      }
+    }
     await prisma.appointment.delete({ where: { id: req.params.id } });
 
     if (appointment.service) {

--- a/src/services/calendar.service.ts
+++ b/src/services/calendar.service.ts
@@ -1,5 +1,7 @@
 import { Appointment, Service } from '@prisma/client';
+import { google, calendar_v3 } from 'googleapis';
 import { BOOKING_TIMEZONE_GOOGLE } from './scheduling.service';
+import { getAccessTokenForProvider } from './oauth/oauth.service';
 
 export interface CalendarEventPayload {
   summary: string;
@@ -13,6 +15,137 @@ export interface CalendarEventPayload {
     timeZone: string;
   };
 }
+
+const DEFAULT_CALENDAR_ID = 'primary';
+let hasWarnedMissingCalendarAuth = false;
+
+const getConfiguredCalendarId = (): string =>
+  process.env.GOOGLE_CALENDAR_ID?.trim() || DEFAULT_CALENDAR_ID;
+
+const isCalendarSyncEnabled = (): boolean => process.env.GOOGLE_CALENDAR_SYNC_ENABLED === 'true';
+const canFallbackToServiceAccount = (): boolean =>
+  process.env.GOOGLE_CALENDAR_ALLOW_SERVICE_ACCOUNT_FALLBACK === 'true';
+
+const getGoogleCalendarAuthMode = (): 'oauth' | 'service_account' => {
+  const mode = process.env.GOOGLE_CALENDAR_AUTH_MODE;
+  return mode === 'service_account' ? 'service_account' : 'oauth';
+};
+
+const getServiceAccountCredentials = (): { client_email: string; private_key: string } | null => {
+  const encoded = process.env.GOOGLE_SERVICE_ACCOUNT_JSON_BASE64;
+  if (encoded) {
+    try {
+      const parsed = JSON.parse(Buffer.from(encoded, 'base64').toString('utf8'));
+      if (parsed?.client_email && parsed?.private_key) {
+        return {
+          client_email: parsed.client_email,
+          private_key: String(parsed.private_key).replace(/\\n/g, '\n'),
+        };
+      }
+    } catch (error) {
+      console.error('Invalid GOOGLE_SERVICE_ACCOUNT_JSON_BASE64:', error);
+      return null;
+    }
+  }
+
+  const rawJson = process.env.GOOGLE_SERVICE_ACCOUNT_JSON;
+  if (rawJson) {
+    try {
+      const parsed = JSON.parse(rawJson);
+      if (parsed?.client_email && parsed?.private_key) {
+        return {
+          client_email: parsed.client_email,
+          private_key: String(parsed.private_key).replace(/\\n/g, '\n'),
+        };
+      }
+    } catch (error) {
+      console.error('Invalid GOOGLE_SERVICE_ACCOUNT_JSON:', error);
+      return null;
+    }
+  }
+
+  const clientEmail = process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL;
+  const privateKey = process.env.GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY;
+  if (clientEmail && privateKey) {
+    return {
+      client_email: clientEmail,
+      private_key: privateKey.replace(/\\n/g, '\n'),
+    };
+  }
+
+  return null;
+};
+
+const getServiceAccountCalendarClient = (): calendar_v3.Calendar | null => {
+  const credentials = getServiceAccountCredentials();
+  if (!credentials) {
+    return null;
+  }
+
+  const auth = new google.auth.JWT({
+    email: credentials.client_email,
+    key: credentials.private_key,
+    scopes: ['https://www.googleapis.com/auth/calendar'],
+  });
+
+  return google.calendar({ version: 'v3', auth });
+};
+
+const getOAuthCalendarClient = async (): Promise<calendar_v3.Calendar | null> => {
+  let accessToken: string | null = null;
+  try {
+    accessToken = await getAccessTokenForProvider('google_calendar');
+  } catch (error: any) {
+    if (error?.code !== 'P2021') {
+      throw error;
+    }
+    // Older DB/test snapshots may not yet include oauth tables.
+    return null;
+  }
+  if (!accessToken) {
+    return null;
+  }
+
+  const auth = new google.auth.OAuth2();
+  auth.setCredentials({ access_token: accessToken });
+  return google.calendar({ version: 'v3', auth });
+};
+
+const getCalendarClient = async (): Promise<calendar_v3.Calendar | null> => {
+  if (!isCalendarSyncEnabled()) {
+    return null;
+  }
+
+  const mode = getGoogleCalendarAuthMode();
+  if (mode === 'service_account') {
+    const serviceAccountClient = getServiceAccountCalendarClient();
+    if (!serviceAccountClient && process.env.NODE_ENV !== 'test' && !hasWarnedMissingCalendarAuth) {
+      console.warn('Google Calendar sync enabled but service account credentials are missing.');
+      hasWarnedMissingCalendarAuth = true;
+    }
+    return serviceAccountClient;
+  }
+
+  const oauthClient = await getOAuthCalendarClient();
+  if (oauthClient) {
+    return oauthClient;
+  }
+
+  if (canFallbackToServiceAccount()) {
+    const fallbackClient = getServiceAccountCalendarClient();
+    if (fallbackClient) {
+      return fallbackClient;
+    }
+  }
+
+  if (process.env.NODE_ENV !== 'test' && !hasWarnedMissingCalendarAuth) {
+    console.warn(
+      'Google Calendar sync enabled but no OAuth connection is active. Complete /api/oauth/google_calendar/authorize.'
+    );
+    hasWarnedMissingCalendarAuth = true;
+  }
+  return null;
+};
 
 export const buildGoogleCalendarEventPayload = (
   appointment: Appointment,
@@ -39,4 +172,60 @@ export const buildGoogleCalendarEventPayload = (
       timeZone: BOOKING_TIMEZONE_GOOGLE,
     },
   };
+};
+
+export const upsertGoogleCalendarEvent = async (
+  appointment: Appointment,
+  service: Service
+): Promise<string | null> => {
+  const calendar = await getCalendarClient();
+  if (!calendar) {
+    return null;
+  }
+
+  const payload = buildGoogleCalendarEventPayload(appointment, service);
+  const calendarId = getConfiguredCalendarId();
+
+  if (appointment.calendarEventId) {
+    try {
+      await calendar.events.update({
+        calendarId,
+        eventId: appointment.calendarEventId,
+        requestBody: payload,
+      });
+      return appointment.calendarEventId;
+    } catch (error: any) {
+      const status = error?.code || error?.response?.status;
+      if (status !== 404) {
+        throw error;
+      }
+    }
+  }
+
+  const created = await calendar.events.insert({
+    calendarId,
+    requestBody: payload,
+  });
+
+  return created.data.id ?? null;
+};
+
+export const deleteGoogleCalendarEvent = async (calendarEventId: string): Promise<void> => {
+  const calendar = await getCalendarClient();
+  if (!calendar) {
+    return;
+  }
+
+  try {
+    await calendar.events.delete({
+      calendarId: getConfiguredCalendarId(),
+      eventId: calendarEventId,
+    });
+  } catch (error: any) {
+    const status = error?.code || error?.response?.status;
+    if (status === 404) {
+      return;
+    }
+    throw error;
+  }
 };


### PR DESCRIPTION
## Summary
- Move Google Calendar sync to OAuth-token-backed auth as primary mode.
- Keep optional service-account fallback behind explicit feature flags.
- Wire appointment lifecycle hooks to OAuth-backed calendar sync behavior.
## Changes
- Updated calendar service to use stored OAuth access tokens for Google Calendar calls.
- Added fallback behavior options for service account credentials.
- Removed redundant payload-only hook calls in appointment routes.
- Updated docs/env guidance for OAuth-first calendar setup.
## Why
Align Google calendar integration with the new OAuth architecture and avoid service-account-only coupling.
## Test Plan
- `npx tsc --noEmit`
- `npm test -- src/__tests__/appointment.test.ts --runInBand`
- `npm test -- src/__tests__/appointment.email.test.ts --runInBand`
- `npm test -- src/__tests__/oauth.routes.test.ts --runInBand`