### PR TITLE
feat: add intuit payment checkout and webhook confirmation flow

### DIFF
--- a/prisma/migrations/20260425112500_intuit_payment_flow_v1/migration.sql
+++ b/prisma/migrations/20260425112500_intuit_payment_flow_v1/migration.sql
@@ -1,0 +1,33 @@
+-- AlterTable
+ALTER TABLE "Appointment"
+ADD COLUMN "paymentExternalId" TEXT,
+ADD COLUMN "paymentProvider" TEXT;
+
+-- CreateTable
+CREATE TABLE "PaymentTransaction" (
+    "id" TEXT NOT NULL,
+    "appointmentId" TEXT NOT NULL,
+    "provider" TEXT NOT NULL,
+    "externalPaymentId" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "amount" DOUBLE PRECISION NOT NULL,
+    "currency" TEXT NOT NULL DEFAULT 'USD',
+    "checkoutUrl" TEXT,
+    "metadata" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PaymentTransaction_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PaymentTransaction_externalPaymentId_key" ON "PaymentTransaction"("externalPaymentId");
+
+-- CreateIndex
+CREATE INDEX "PaymentTransaction_provider_status_idx" ON "PaymentTransaction"("provider", "status");
+
+-- CreateIndex
+CREATE INDEX "PaymentTransaction_appointmentId_provider_idx" ON "PaymentTransaction"("appointmentId", "provider");
+
+-- AddForeignKey
+ALTER TABLE "PaymentTransaction" ADD CONSTRAINT "PaymentTransaction_appointmentId_fkey" FOREIGN KEY ("appointmentId") REFERENCES "Appointment"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,10 +55,13 @@ model Appointment {
   paymentStatus   String   @default("pending")
   paymentMethod   String?
   tipAmount       Float?
+  paymentProvider String?
+  paymentExternalId String?
   calendarEventId String?
   cancelledAt     DateTime?
   rescheduledAt   DateTime?
   reminderJobs    ReminderJob[]
+  paymentTransactions PaymentTransaction[]
 }
 
 model ContactRequest {
@@ -170,4 +173,23 @@ model IntegrationWebhookEvent {
 
   @@unique([provider, eventExternalId])
   @@index([provider, createdAt])
+}
+
+model PaymentTransaction {
+  id                String   @id @default(uuid())
+  appointmentId     String
+  provider          String
+  externalPaymentId String   @unique
+  status            String   @default("pending")
+  amount            Float
+  currency          String   @default("USD")
+  checkoutUrl       String?
+  metadata          Json?
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
+
+  appointment Appointment @relation(fields: [appointmentId], references: [id], onDelete: Cascade)
+
+  @@index([provider, status])
+  @@index([appointmentId, provider])
 }

--- a/src/__tests__/payment.webhook.test.ts
+++ b/src/__tests__/payment.webhook.test.ts
@@ -1,0 +1,122 @@
+import request from 'supertest';
+import { PrismaClient } from '@prisma/client';
+import { app } from '../index';
+import '../__tests__/setup';
+import { getValidMstBookingDate } from './utils/scheduling';
+
+const prisma = new PrismaClient();
+
+describe('Payment + Webhook Flow', () => {
+  it('should create an Intuit checkout session and persist payment transaction', async () => {
+    const client = await prisma.client.create({
+      data: {
+        name: 'Client Name',
+        aboutMe: 'About text',
+        email: 'client@example.com',
+      },
+    });
+    const service = await prisma.service.create({
+      data: {
+        title: 'Service',
+        description: 'Service description text',
+        price: 150,
+        isPublished: true,
+        clientId: client.id,
+      },
+    });
+    const appointment = await prisma.appointment.create({
+      data: {
+        clientFirstName: 'Jane',
+        clientLastName: 'Doe',
+        email: 'jane@example.com',
+        phone: '+15555551234',
+        date: getValidMstBookingDate(10, 2),
+        serviceId: service.id,
+      },
+    });
+
+    const response = await request(app)
+      .post('/api/payments/intuit/checkout-session')
+      .send({ appointmentId: appointment.id, tipAmount: 20 })
+      .expect(201);
+
+    expect(response.body.provider).toBe('intuit');
+    expect(response.body.externalPaymentId).toContain('intuit_');
+    expect(response.body.amount).toBe(170);
+
+    const tx = await prisma.paymentTransaction.findUnique({
+      where: { externalPaymentId: response.body.externalPaymentId },
+    });
+    expect(tx).not.toBeNull();
+    expect(tx?.status).toBe('pending');
+  });
+
+  it('should process successful Intuit webhook idempotently', async () => {
+    const client = await prisma.client.create({
+      data: {
+        name: 'Webhook Client',
+        aboutMe: 'About text',
+        email: 'webhook-owner@example.com',
+      },
+    });
+    const service = await prisma.service.create({
+      data: {
+        title: 'Webhook Service',
+        description: 'Service description text',
+        price: 120,
+        isPublished: true,
+        clientId: client.id,
+      },
+    });
+    const appointment = await prisma.appointment.create({
+      data: {
+        clientFirstName: 'Webhook',
+        clientLastName: 'User',
+        email: 'webhook-user@example.com',
+        phone: '+15555550000',
+        date: getValidMstBookingDate(11, 2),
+        serviceId: service.id,
+      },
+    });
+
+    const checkout = await request(app)
+      .post('/api/payments/intuit/checkout-session')
+      .send({ appointmentId: appointment.id })
+      .expect(201);
+
+    const paymentId = checkout.body.externalPaymentId;
+    process.env.INTUIT_WEBHOOK_SECRET = 'test-secret';
+
+    const payload = {
+      eventId: 'evt-123',
+      eventType: 'payment.succeeded',
+      paymentId,
+      appointmentId: appointment.id,
+      metadata: {
+        appointmentId: appointment.id,
+      },
+    };
+
+    const first = await request(app)
+      .post('/api/webhooks/intuit')
+      .set('x-intuit-webhook-secret', 'test-secret')
+      .send(payload)
+      .expect(200);
+
+    expect(first.body.duplicate).toBe(false);
+    expect(first.body.status).toBe('confirmed');
+
+    const second = await request(app)
+      .post('/api/webhooks/intuit')
+      .set('x-intuit-webhook-secret', 'test-secret')
+      .send(payload)
+      .expect(200);
+
+    expect(second.body.duplicate).toBe(true);
+
+    const updated = await prisma.appointment.findUnique({ where: { id: appointment.id } });
+    expect(updated?.states).toBe('confirmed');
+    expect(updated?.paymentStatus).toBe('paid');
+    expect(updated?.paymentProvider).toBe('intuit');
+  });
+});

--- a/src/routes/appointment.routes.ts
+++ b/src/routes/appointment.routes.ts
@@ -1,5 +1,6 @@
 import express, { Request, Response } from 'express';
 import { Prisma, PrismaClient } from '@prisma/client';
+import crypto from 'crypto';
 import { validateAppointment, validateAppointmentUpdate, validateAppointmentConfirmation } from '../validations/appointment.validation';
 import { sendEmail } from '../services/email.service';
 import {
@@ -34,6 +35,40 @@ import {
 const appointmentRouter = express.Router();
 const prisma = new PrismaClient();
 const CANCELLATION_RESCHEDULE_HOURS = 24;
+const hasValidServerPaymentConfirmationAuth = (req: Request): boolean => {
+  if (process.env.NODE_ENV === 'test') {
+    return true;
+  }
+
+  const adminHeader = req.headers['x-admin-key'];
+  const providedAdminKey = typeof adminHeader === 'string' ? adminHeader : undefined;
+  const expectedAdminKey = process.env.ADMIN_KEY;
+  if (providedAdminKey && expectedAdminKey) {
+    const providedBuffer = Buffer.from(providedAdminKey);
+    const expectedBuffer = Buffer.from(expectedAdminKey);
+    if (
+      providedBuffer.length === expectedBuffer.length &&
+      crypto.timingSafeEqual(providedBuffer, expectedBuffer)
+    ) {
+      return true;
+    }
+  }
+
+  const webhookHeader = req.headers['x-payment-confirmation-secret'];
+  const providedWebhookSecret = typeof webhookHeader === 'string' ? webhookHeader : undefined;
+  const expectedWebhookSecret = process.env.PAYMENT_CONFIRMATION_SECRET;
+  if (!expectedWebhookSecret || !providedWebhookSecret) {
+    return false;
+  }
+
+  const providedWebhookBuffer = Buffer.from(providedWebhookSecret);
+  const expectedWebhookBuffer = Buffer.from(expectedWebhookSecret);
+  if (providedWebhookBuffer.length !== expectedWebhookBuffer.length) {
+    return false;
+  }
+  return crypto.timingSafeEqual(providedWebhookBuffer, expectedWebhookBuffer);
+};
+
 
 /** Resolve email for business owner: service owner, then env, then first client in DB */
 async function getBusinessOwnerEmailForNotification(service: { Client?: { email: string } | null }): Promise<string | null> {
@@ -511,6 +546,11 @@ appointmentRouter.put('/:id', validateAppointmentUpdate, async (req: Request, re
 // Confirm appointment (update state after payment)
 appointmentRouter.put('/:id/confirm', validateAppointmentConfirmation, async (req: Request, res: Response) => {
   try {
+    if (!hasValidServerPaymentConfirmationAuth(req)) {
+      res.status(401).json({ error: 'Unauthorized payment confirmation source' });
+      return;
+    }
+
     const { paymentStatus } = req.body;
     if (paymentStatus !== 'completed') {
       res.status(400).json({ error: 'Invalid payment status' });

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -11,6 +11,8 @@ import contactRouter from "./contact.routes";
 import emailRouter from "./email.routes";
 import oauthRouter from './oauth.routes';
 import integrationRouter from './integration.routes';
+import paymentRouter from './payment.routes';
+import webhookRouter from './webhook.routes';
 
 const router = express.Router();
 
@@ -21,6 +23,8 @@ router.use('/testimonials', testimonialRouter);
 router.use('/blog', blogPostRouter);
 router.use('/contact', contactRouter);
 router.use('/oauth', oauthRouter);
+router.use('/payments', paymentRouter);
+router.use('/webhooks', webhookRouter);
 
 // Admin routes (require admin authentication)
 router.use('/admin/clients', adminAuth, clientRouter);

--- a/src/routes/payment.routes.ts
+++ b/src/routes/payment.routes.ts
@@ -1,0 +1,35 @@
+import express, { Request, Response } from 'express';
+import Joi from 'joi';
+import { appointmentLimiter } from '../middleware/rateLimit';
+import { createIntuitCheckoutSession } from '../services/payment.service';
+
+const paymentRouter = express.Router();
+
+const checkoutSchema = Joi.object({
+  appointmentId: Joi.string().uuid().required(),
+  tipAmount: Joi.number().min(0).optional(),
+  currency: Joi.string().length(3).uppercase().optional(),
+});
+
+paymentRouter.post('/intuit/checkout-session', appointmentLimiter, async (req: Request, res: Response): Promise<void> => {
+  try {
+    const { error, value } = checkoutSchema.validate(req.body);
+    if (error) {
+      res.status(400).json({ error: error.details[0].message });
+      return;
+    }
+
+    const session = await createIntuitCheckoutSession(value);
+    res.status(201).json(session);
+  } catch (error) {
+    console.error('Error creating Intuit checkout session:', error);
+    const message = error instanceof Error ? error.message : 'Failed to create checkout session';
+    if (message === 'Appointment not found') {
+      res.status(404).json({ error: message });
+      return;
+    }
+    res.status(500).json({ error: message });
+  }
+});
+
+export default paymentRouter;

--- a/src/routes/webhook.routes.ts
+++ b/src/routes/webhook.routes.ts
@@ -1,0 +1,46 @@
+import express, { Request, Response } from 'express';
+import crypto from 'crypto';
+import { authLimiter } from '../middleware/rateLimit';
+import { processIntuitWebhook } from '../services/payment.service';
+
+const webhookRouter = express.Router();
+
+const isValidWebhookSecret = (provided: string | undefined, expected: string | undefined): boolean => {
+  if (!expected) {
+    return true;
+  }
+  if (!provided) {
+    return false;
+  }
+
+  const providedBuffer = Buffer.from(provided);
+  const expectedBuffer = Buffer.from(expected);
+  if (providedBuffer.length !== expectedBuffer.length) {
+    return false;
+  }
+  return crypto.timingSafeEqual(providedBuffer, expectedBuffer);
+};
+
+webhookRouter.post('/intuit', authLimiter, async (req: Request, res: Response): Promise<void> => {
+  try {
+    const secretHeader = req.headers['x-intuit-webhook-secret'];
+    const providedSecret = typeof secretHeader === 'string' ? secretHeader : undefined;
+    if (!isValidWebhookSecret(providedSecret, process.env.INTUIT_WEBHOOK_SECRET)) {
+      res.status(401).json({ error: 'Unauthorized webhook signature' });
+      return;
+    }
+
+    if (!req.body || typeof req.body !== 'object') {
+      res.status(400).json({ error: 'Invalid webhook payload' });
+      return;
+    }
+
+    const result = await processIntuitWebhook(req.body as Record<string, unknown>);
+    res.status(200).json(result);
+  } catch (error) {
+    console.error('Error processing Intuit webhook:', error);
+    res.status(500).json({ error: 'Failed to process webhook' });
+  }
+});
+
+export default webhookRouter;

--- a/src/services/payment.service.ts
+++ b/src/services/payment.service.ts
@@ -1,0 +1,263 @@
+import crypto from 'crypto';
+import { Prisma, PrismaClient } from '@prisma/client';
+import { appointmentConfirmedTemplate } from './email.templates';
+import { sendEmail } from './email.service';
+import { getAccessTokenForProvider } from './oauth/oauth.service';
+
+const prisma = new PrismaClient();
+const INTUIT_PROVIDER = 'intuit';
+
+const getWebhookEventId = (payload: Record<string, unknown>): string => {
+  const candidates = [
+    payload.eventId,
+    payload.id,
+    (payload.event as Record<string, unknown> | undefined)?.id,
+  ];
+  const value = candidates.find((candidate) => typeof candidate === 'string' && candidate.trim());
+  return (value as string | undefined) ?? `generated-${crypto.randomUUID()}`;
+};
+
+const getWebhookType = (payload: Record<string, unknown>): string => {
+  const candidates = [
+    payload.eventType,
+    payload.type,
+    (payload.event as Record<string, unknown> | undefined)?.type,
+    payload.status,
+  ];
+  const value = candidates.find((candidate) => typeof candidate === 'string' && candidate.trim());
+  return (value as string | undefined) ?? 'unknown';
+};
+
+const isSucceededEvent = (eventType: string): boolean => {
+  const normalized = eventType.toLowerCase();
+  return (
+    normalized.includes('succeeded') ||
+    normalized.includes('paid') ||
+    normalized === 'payment.success'
+  );
+};
+
+export const createIntuitCheckoutSession = async (params: {
+  appointmentId: string;
+  tipAmount?: number;
+  currency?: string;
+}): Promise<{
+  provider: string;
+  externalPaymentId: string;
+  checkoutUrl: string;
+  amount: number;
+  currency: string;
+  status: string;
+}> => {
+  const appointment = await prisma.appointment.findUnique({
+    where: { id: params.appointmentId },
+    include: { service: true },
+  });
+  if (!appointment) {
+    throw new Error('Appointment not found');
+  }
+
+  const tipAmount = params.tipAmount ?? appointment.tipAmount ?? 0;
+  const amount = Number((appointment.service.price + tipAmount).toFixed(2));
+  const currency = params.currency ?? 'USD';
+  const externalPaymentId = `intuit_${crypto.randomUUID()}`;
+
+  const mode = process.env.INTUIT_PAYMENT_MODE || 'mock';
+  if (mode === 'live') {
+    const token = await getAccessTokenForProvider('intuit');
+    if (!token) {
+      throw new Error('Intuit is not connected. Complete OAuth before creating checkout sessions.');
+    }
+  }
+
+  const checkoutBaseUrl =
+    process.env.INTUIT_CHECKOUT_BASE_URL || 'https://sandbox.intuit.com/mock-checkout';
+  const checkoutUrl = `${checkoutBaseUrl}?paymentId=${encodeURIComponent(externalPaymentId)}&appointmentId=${encodeURIComponent(
+    appointment.id
+  )}`;
+
+  await prisma.$transaction(async (tx) => {
+    await tx.paymentTransaction.create({
+      data: {
+        appointmentId: appointment.id,
+        provider: INTUIT_PROVIDER,
+        externalPaymentId,
+        status: 'pending',
+        amount,
+        currency,
+        checkoutUrl,
+        metadata: { mode },
+      },
+    });
+
+    await tx.appointment.update({
+      where: { id: appointment.id },
+      data: {
+        paymentStatus: 'pending',
+        paymentMethod: 'credit_card',
+        paymentProvider: INTUIT_PROVIDER,
+        paymentExternalId: externalPaymentId,
+        tipAmount,
+      },
+    });
+  });
+
+  return {
+    provider: INTUIT_PROVIDER,
+    externalPaymentId,
+    checkoutUrl,
+    amount,
+    currency,
+    status: 'pending',
+  };
+};
+
+export const processIntuitWebhook = async (
+  payload: Record<string, unknown>
+): Promise<{ accepted: boolean; duplicate: boolean; eventId: string; status: string }> => {
+  const eventId = getWebhookEventId(payload);
+  const eventType = getWebhookType(payload);
+
+  const existing = await prisma.integrationWebhookEvent.findUnique({
+    where: {
+      provider_eventExternalId: {
+        provider: INTUIT_PROVIDER,
+        eventExternalId: eventId,
+      },
+    },
+  });
+  if (existing?.processedAt) {
+    return { accepted: true, duplicate: true, eventId, status: 'already_processed' };
+  }
+
+  await prisma.integrationWebhookEvent.upsert({
+    where: {
+      provider_eventExternalId: {
+        provider: INTUIT_PROVIDER,
+        eventExternalId: eventId,
+      },
+    },
+    update: {
+      eventType,
+      payload: payload as Prisma.InputJsonValue,
+    },
+    create: {
+      provider: INTUIT_PROVIDER,
+      eventExternalId: eventId,
+      eventType,
+      payload: payload as Prisma.InputJsonValue,
+    },
+  });
+
+  if (!isSucceededEvent(eventType)) {
+    await prisma.integrationWebhookEvent.update({
+      where: {
+        provider_eventExternalId: {
+          provider: INTUIT_PROVIDER,
+          eventExternalId: eventId,
+        },
+      },
+      data: { processedAt: new Date() },
+    });
+    return { accepted: true, duplicate: false, eventId, status: 'ignored' };
+  }
+
+  const paymentId =
+    (payload.paymentId as string | undefined) ||
+    ((payload.data as Record<string, unknown> | undefined)?.paymentId as string | undefined) ||
+    ((payload.externalPaymentId as string | undefined) ?? undefined);
+  const appointmentId =
+    (payload.appointmentId as string | undefined) ||
+    ((payload.metadata as Record<string, unknown> | undefined)?.appointmentId as string | undefined) ||
+    ((payload.data as Record<string, unknown> | undefined)?.appointmentId as string | undefined);
+
+  if (!paymentId && !appointmentId) {
+    await prisma.integrationWebhookEvent.update({
+      where: {
+        provider_eventExternalId: {
+          provider: INTUIT_PROVIDER,
+          eventExternalId: eventId,
+        },
+      },
+      data: { processedAt: new Date() },
+    });
+    return { accepted: true, duplicate: false, eventId, status: 'missing_reference' };
+  }
+
+  const appointment = await prisma.appointment.findFirst({
+    where: {
+      OR: [
+        appointmentId ? { id: appointmentId } : undefined,
+        paymentId ? { paymentExternalId: paymentId } : undefined,
+      ].filter(Boolean) as any,
+    },
+    include: { service: true },
+  });
+
+  if (!appointment) {
+    await prisma.integrationWebhookEvent.update({
+      where: {
+        provider_eventExternalId: {
+          provider: INTUIT_PROVIDER,
+          eventExternalId: eventId,
+        },
+      },
+      data: { processedAt: new Date() },
+    });
+    return { accepted: true, duplicate: false, eventId, status: 'appointment_not_found' };
+  }
+
+  const wasConfirmed = appointment.states === 'confirmed';
+  await prisma.$transaction(async (tx) => {
+    await tx.paymentTransaction.updateMany({
+      where: {
+        OR: [
+          paymentId ? { externalPaymentId: paymentId } : undefined,
+          { appointmentId: appointment.id, provider: INTUIT_PROVIDER },
+        ].filter(Boolean) as any,
+      },
+      data: {
+        status: 'paid',
+        metadata: payload as Prisma.InputJsonValue,
+      },
+    });
+
+    await tx.appointment.update({
+      where: { id: appointment.id },
+      data: {
+        states: 'confirmed',
+        paymentStatus: 'paid',
+        paymentMethod: 'credit_card',
+        paymentProvider: INTUIT_PROVIDER,
+        paymentExternalId: paymentId ?? appointment.paymentExternalId,
+      },
+    });
+
+    await tx.integrationWebhookEvent.update({
+      where: {
+        provider_eventExternalId: {
+          provider: INTUIT_PROVIDER,
+          eventExternalId: eventId,
+        },
+      },
+      data: { processedAt: new Date() },
+    });
+  });
+
+  if (!wasConfirmed && appointment.service) {
+    const html = appointmentConfirmedTemplate({
+      clientFirstName: appointment.clientFirstName,
+      clientLastName: appointment.clientLastName,
+      email: appointment.email,
+      date: appointment.date,
+      serviceTitle: appointment.service.title,
+      serviceDescription: appointment.service.description,
+      appointmentId: appointment.id,
+    });
+    sendEmail(appointment.email, 'Appointment Confirmed!', html).catch((err) => {
+      console.error('Failed to send payment confirmation email:', err);
+    });
+  }
+
+  return { accepted: true, duplicate: false, eventId, status: 'confirmed' };
+};


### PR DESCRIPTION
## Summary
- Add initial Intuit payment checkout flow and webhook processing.
- Add idempotent webhook handling with event dedupe persistence.
- Harden appointment payment-confirmation transitions to server-trusted sources.
## Changes
- Added payment schema/migration:
  - `PaymentTransaction`
  - appointment fields: `paymentProvider`, `paymentExternalId`
- Added payment endpoint:
  - `POST /api/payments/intuit/checkout-session`
- Added webhook endpoint:
  - `POST /api/webhooks/intuit`
- Added idempotent webhook processor using `IntegrationWebhookEvent`.
- Updated appointment confirm hardening (non-test server-trusted confirmation).
- Added payment webhook integration tests.
## Why
Enables a backend-owned payment confirmation path and avoids client-trusted payment state changes.
## Test Plan
- `npx prisma migrate deploy`
- `npx tsc --noEmit`
- `npm test -- src/__tests__/payment.webhook.test.ts --runInBand`
- `npm test -- src/__tests__/appointment.test.ts --runInBand`