### PR TITLE
docs: finalize oauth and payment integration contracts

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -403,6 +403,28 @@ Supported providers:
 
 - `google_calendar`
 - `intuit`
+
+## 14) Intuit Payment Flow (v1)
+
+Checkout creation:
+
+- `POST /api/payments/intuit/checkout-session`
+- creates a `PaymentTransaction` with `pending` status
+- stores `paymentProvider=intuit` and `paymentExternalId` on the appointment
+
+Webhook processing:
+
+- `POST /api/webhooks/intuit`
+- optional shared-secret protection via `INTUIT_WEBHOOK_SECRET` and `x-intuit-webhook-secret` header
+- deduplicates events with `IntegrationWebhookEvent` (`provider + eventExternalId`)
+- on succeeded events, marks appointment as paid/confirmed and updates related payment transaction records
+
+Server-trusted confirmation:
+
+- `PUT /api/appointments/:id/confirm` is hardened for non-test environments
+- requires one of:
+  - valid `x-admin-key`, or
+  - valid `x-payment-confirmation-secret` matching `PAYMENT_CONFIRMATION_SECRET`
 - Prisma schema + seed:
   - `prisma/schema.prisma`
   - `prisma/seed.ts`

--- a/README.md
+++ b/README.md
@@ -67,6 +67,27 @@ New admin diagnostics endpoints:
 - `GET /api/admin/integrations/intuit/status`
 - `POST /api/admin/integrations/intuit/refresh`
 
+## Intuit Payments + Webhooks (v1)
+
+```env
+# payment checkout mode: mock (default) or live
+INTUIT_PAYMENT_MODE=mock
+
+# optional checkout redirect base (mock/demo)
+INTUIT_CHECKOUT_BASE_URL=https://sandbox.intuit.com/mock-checkout
+
+# webhook shared secret (optional but recommended)
+INTUIT_WEBHOOK_SECRET=replace-me
+
+# server-side appointment confirmation secret (for /appointments/:id/confirm)
+PAYMENT_CONFIRMATION_SECRET=replace-me
+```
+
+Payment endpoints:
+
+- `POST /api/payments/intuit/checkout-session`
+- `POST /api/webhooks/intuit`
+
 ## Test Commands
 
 ```bash

--- a/docs/frontend-api-client.ts
+++ b/docs/frontend-api-client.ts
@@ -40,7 +40,18 @@ export interface Appointment {
   paymentStatus?: string;
   paymentMethod?: string | null;
   tipAmount?: number | null;
+  paymentProvider?: string | null;
+  paymentExternalId?: string | null;
   service?: Service;
+}
+
+export interface CheckoutSession {
+  provider: string;
+  externalPaymentId: string;
+  checkoutUrl: string;
+  amount: number;
+  currency: string;
+  status: string;
 }
 
 export interface ContactRequest {
@@ -132,7 +143,8 @@ export class MomsWebsiteApiClient {
     path: string,
     method: HttpMethod = 'GET',
     body?: unknown,
-    requiresAdmin: boolean = false
+    requiresAdmin: boolean = false,
+    extraHeaders?: Record<string, string>
   ): Promise<T> {
     const headers: Record<string, string> = {};
     if (body !== undefined) {
@@ -143,6 +155,9 @@ export class MomsWebsiteApiClient {
         throw new ApiError(401, 'Admin key is required for this endpoint');
       }
       headers['x-admin-key'] = this.adminKey;
+    }
+    if (extraHeaders) {
+      Object.assign(headers, extraHeaders);
     }
 
     const response = await this.fetchImpl(`${this.baseUrl}${path}`, {
@@ -204,11 +219,15 @@ export class MomsWebsiteApiClient {
     return this.request(`/appointments/${appointmentId}`, 'PUT', input);
   }
 
-  confirmAppointment(appointmentId: string): Promise<Appointment> {
+  confirmAppointment(appointmentId: string, paymentConfirmationSecret?: string): Promise<Appointment> {
+    const headers =
+      paymentConfirmationSecret && paymentConfirmationSecret.trim()
+        ? { 'x-payment-confirmation-secret': paymentConfirmationSecret }
+        : undefined;
     return this.request(`/appointments/${appointmentId}/confirm`, 'PUT', {
       appointmentId,
       paymentStatus: 'completed',
-    });
+    }, false, headers);
   }
 
   deleteAppointment(appointmentId: string): Promise<void> {
@@ -343,6 +362,60 @@ export class MomsWebsiteApiClient {
 
   adminDispatchReminderJobs(): Promise<{ status: string; message: string; processed: number; sent: number; failed: number }> {
     return this.request('/admin/email/reminders/dispatch', 'POST', undefined, true);
+  }
+
+  // OAuth + integration diagnostics
+  adminCreateOAuthAuthorization(provider: 'google_calendar' | 'intuit', input?: { ownerKey?: string; redirectPath?: string; clientId?: string }): Promise<{ state: string; authorizationUrl: string }> {
+    return this.request(`/oauth/${provider}/authorize`, 'POST', input ?? {}, true);
+  }
+
+  adminGetOAuthStatus(provider: 'google_calendar' | 'intuit', ownerKey?: string): Promise<{
+    provider: string;
+    ownerKey: string;
+    connected: boolean;
+    expiresAt: string | null;
+    scopes: string[];
+    updatedAt: string | null;
+    metadata: Record<string, unknown> | null;
+  }> {
+    const params = new URLSearchParams();
+    if (ownerKey) params.set('ownerKey', ownerKey);
+    const suffix = params.toString() ? `?${params.toString()}` : '';
+    return this.request(`/oauth/${provider}/status${suffix}`, 'GET', undefined, true);
+  }
+
+  adminGetIntegrationStatus(provider: 'google_calendar' | 'intuit', ownerKey?: string): Promise<{
+    provider: string;
+    ownerKey: string;
+    connected: boolean;
+    expiresAt: string | null;
+    scopes: string[];
+    updatedAt: string | null;
+    metadata: Record<string, unknown> | null;
+  }> {
+    const params = new URLSearchParams();
+    if (ownerKey) params.set('ownerKey', ownerKey);
+    const suffix = params.toString() ? `?${params.toString()}` : '';
+    return this.request(`/admin/integrations/${provider}/status${suffix}`, 'GET', undefined, true);
+  }
+
+  adminRefreshIntegration(provider: 'google_calendar' | 'intuit', ownerKey?: string): Promise<{
+    provider: string;
+    ownerKey: string;
+    refreshed: boolean;
+    accessTokenAvailable: boolean;
+    connected: boolean;
+    expiresAt: string | null;
+    scopes: string[];
+    updatedAt: string | null;
+    metadata: Record<string, unknown> | null;
+  }> {
+    return this.request(`/admin/integrations/${provider}/refresh`, 'POST', ownerKey ? { ownerKey } : {}, true);
+  }
+
+  // Payments
+  createIntuitCheckoutSession(input: { appointmentId: string; tipAmount?: number; currency?: string }): Promise<CheckoutSession> {
+    return this.request('/payments/intuit/checkout-session', 'POST', input);
   }
 }
 

--- a/docs/postman_collection.json
+++ b/docs/postman_collection.json
@@ -13,7 +13,11 @@
     { "key": "clientId", "value": "" },
     { "key": "blogPostId", "value": "" },
     { "key": "testimonialId", "value": "" },
-    { "key": "contactId", "value": "" }
+    { "key": "contactId", "value": "" },
+    { "key": "paymentId", "value": "" },
+    { "key": "ownerKey", "value": "global" },
+    { "key": "paymentConfirmationSecret", "value": "" },
+    { "key": "intuitWebhookSecret", "value": "" }
   ],
   "item": [
     {
@@ -123,7 +127,10 @@
           "name": "PUT /appointments/:id/confirm",
           "request": {
             "method": "PUT",
-            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "x-payment-confirmation-secret", "value": "{{paymentConfirmationSecret}}" }
+            ],
             "body": {
               "mode": "raw",
               "raw": "{\n  \"appointmentId\": \"{{appointmentId}}\",\n  \"paymentStatus\": \"completed\"\n}"
@@ -433,6 +440,114 @@
             "method": "POST",
             "header": [{ "key": "x-admin-key", "value": "{{adminKey}}" }],
             "url": { "raw": "{{baseUrl}}/admin/email/reminders/dispatch", "host": ["{{baseUrl}}"], "path": ["admin", "email", "reminders", "dispatch"] }
+          }
+        }
+      ]
+    },
+    {
+      "name": "OAuth + Integrations",
+      "item": [
+        {
+          "name": "POST /oauth/google_calendar/authorize",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "x-admin-key", "value": "{{adminKey}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"redirectPath\": \"/settings/integrations\",\n  \"ownerKey\": \"{{ownerKey}}\"\n}"
+            },
+            "url": { "raw": "{{baseUrl}}/oauth/google_calendar/authorize", "host": ["{{baseUrl}}"], "path": ["oauth", "google_calendar", "authorize"] }
+          }
+        },
+        {
+          "name": "POST /oauth/intuit/authorize",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "x-admin-key", "value": "{{adminKey}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"redirectPath\": \"/settings/integrations\",\n  \"ownerKey\": \"{{ownerKey}}\"\n}"
+            },
+            "url": { "raw": "{{baseUrl}}/oauth/intuit/authorize", "host": ["{{baseUrl}}"], "path": ["oauth", "intuit", "authorize"] }
+          }
+        },
+        {
+          "name": "GET /oauth/intuit/status",
+          "request": {
+            "method": "GET",
+            "header": [{ "key": "x-admin-key", "value": "{{adminKey}}" }],
+            "url": {
+              "raw": "{{baseUrl}}/oauth/intuit/status?ownerKey={{ownerKey}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["oauth", "intuit", "status"],
+              "query": [{ "key": "ownerKey", "value": "{{ownerKey}}" }]
+            }
+          }
+        },
+        {
+          "name": "GET /admin/integrations/intuit/status",
+          "request": {
+            "method": "GET",
+            "header": [{ "key": "x-admin-key", "value": "{{adminKey}}" }],
+            "url": {
+              "raw": "{{baseUrl}}/admin/integrations/intuit/status?ownerKey={{ownerKey}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["admin", "integrations", "intuit", "status"],
+              "query": [{ "key": "ownerKey", "value": "{{ownerKey}}" }]
+            }
+          }
+        },
+        {
+          "name": "POST /admin/integrations/intuit/refresh",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "x-admin-key", "value": "{{adminKey}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"ownerKey\": \"{{ownerKey}}\"\n}"
+            },
+            "url": { "raw": "{{baseUrl}}/admin/integrations/intuit/refresh", "host": ["{{baseUrl}}"], "path": ["admin", "integrations", "intuit", "refresh"] }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Payments + Webhooks",
+      "item": [
+        {
+          "name": "POST /payments/intuit/checkout-session",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"appointmentId\": \"{{appointmentId}}\",\n  \"tipAmount\": 15,\n  \"currency\": \"USD\"\n}"
+            },
+            "url": { "raw": "{{baseUrl}}/payments/intuit/checkout-session", "host": ["{{baseUrl}}"], "path": ["payments", "intuit", "checkout-session"] }
+          }
+        },
+        {
+          "name": "POST /webhooks/intuit",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "x-intuit-webhook-secret", "value": "{{intuitWebhookSecret}}" },
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"eventId\": \"evt-001\",\n  \"eventType\": \"payment.succeeded\",\n  \"paymentId\": \"{{paymentId}}\",\n  \"appointmentId\": \"{{appointmentId}}\",\n  \"metadata\": {\n    \"appointmentId\": \"{{appointmentId}}\"\n  }\n}"
+            },
+            "url": { "raw": "{{baseUrl}}/webhooks/intuit", "host": ["{{baseUrl}}"], "path": ["webhooks", "intuit"] }
           }
         }
       ]

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -20,6 +20,10 @@ tags:
   - name: Admin Testimonials
   - name: Admin Blog
   - name: Admin Email
+  - name: OAuth
+  - name: Integrations
+  - name: Payments
+  - name: Webhooks
 
 paths:
   /:
@@ -233,6 +237,7 @@ paths:
     put:
       tags: [Appointments]
       summary: Confirm appointment after payment
+      description: Requires server-trusted source outside test mode.
       operationId: confirmAppointment
       parameters:
         - $ref: "#/components/parameters/IdPath"
@@ -251,6 +256,236 @@ paths:
                 $ref: "#/components/schemas/Appointment"
         "400":
           $ref: "#/components/responses/BadRequest"
+        "401":
+          description: Unauthorized payment confirmation source
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /payments/intuit/checkout-session:
+    post:
+      tags: [Payments]
+      summary: Create Intuit checkout session for appointment
+      operationId: createIntuitCheckoutSession
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/IntuitCheckoutSessionRequest"
+      responses:
+        "201":
+          description: Checkout session created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IntuitCheckoutSessionResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          description: Appointment not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /webhooks/intuit:
+    post:
+      tags: [Webhooks]
+      summary: Process Intuit payment webhook
+      operationId: processIntuitWebhook
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+      responses:
+        "200":
+          description: Webhook accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IntuitWebhookProcessResponse"
+        "401":
+          description: Unauthorized webhook signature
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /oauth/{provider}/authorize:
+    post:
+      tags: [OAuth]
+      summary: Create OAuth authorization URL for provider
+      operationId: createOAuthAuthorizationUrl
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - $ref: "#/components/parameters/ProviderPath"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OAuthAuthorizeRequest"
+      responses:
+        "200":
+          description: Authorization URL created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OAuthAuthorizeResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /oauth/callback/{provider}:
+    get:
+      tags: [OAuth]
+      summary: OAuth callback endpoint
+      operationId: oauthCallback
+      parameters:
+        - $ref: "#/components/parameters/ProviderPath"
+        - in: query
+          name: code
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: state
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OAuth callback processed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OAuthCallbackResponse"
+        "302":
+          description: Redirected to configured frontend path
+        "400":
+          $ref: "#/components/responses/BadRequest"
+
+  /oauth/{provider}/status:
+    get:
+      tags: [OAuth]
+      summary: Get OAuth provider connection status
+      operationId: getOAuthProviderStatus
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - $ref: "#/components/parameters/ProviderPath"
+        - in: query
+          name: ownerKey
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OAuth connection status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IntegrationStatusResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /oauth/{provider}/connection:
+    delete:
+      tags: [OAuth]
+      summary: Disconnect OAuth provider connection
+      operationId: disconnectOAuthProvider
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - $ref: "#/components/parameters/ProviderPath"
+        - in: query
+          name: ownerKey
+          schema:
+            type: string
+      responses:
+        "204":
+          description: Provider disconnected
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /admin/integrations/{provider}/status:
+    get:
+      tags: [Integrations]
+      summary: Admin integration status diagnostics
+      operationId: adminGetIntegrationStatus
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - $ref: "#/components/parameters/ProviderPath"
+        - in: query
+          name: ownerKey
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Integration status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IntegrationStatusResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /admin/integrations/{provider}/refresh:
+    post:
+      tags: [Integrations]
+      summary: Force refresh integration access token
+      operationId: adminRefreshIntegrationToken
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - $ref: "#/components/parameters/ProviderPath"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ownerKey:
+                  type: string
+      responses:
+        "200":
+          description: Integration refreshed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IntegrationRefreshResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         "500":
           $ref: "#/components/responses/InternalServerError"
 
@@ -1040,6 +1275,14 @@ components:
       schema:
         type: string
       description: Resource identifier
+    ProviderPath:
+      in: path
+      name: provider
+      required: true
+      schema:
+        type: string
+        enum: [google_calendar, intuit]
+      description: OAuth/integration provider identifier
 
   responses:
     BadRequest:
@@ -1192,6 +1435,12 @@ components:
         tipAmount:
           type: number
           nullable: true
+        paymentProvider:
+          type: string
+          nullable: true
+        paymentExternalId:
+          type: string
+          nullable: true
         calendarEventId:
           type: string
           nullable: true
@@ -1282,6 +1531,125 @@ components:
         paymentStatus:
           type: string
           enum: [completed, pending, failed]
+
+    OAuthAuthorizeRequest:
+      type: object
+      properties:
+        redirectPath:
+          type: string
+        ownerKey:
+          type: string
+        clientId:
+          type: string
+          format: uuid
+
+    OAuthAuthorizeResponse:
+      type: object
+      properties:
+        state:
+          type: string
+        authorizationUrl:
+          type: string
+          format: uri
+      required: [state, authorizationUrl]
+
+    OAuthCallbackResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          example: connected
+        provider:
+          type: string
+        ownerKey:
+          type: string
+      required: [status, provider, ownerKey]
+
+    IntegrationStatusResponse:
+      type: object
+      properties:
+        provider:
+          type: string
+        ownerKey:
+          type: string
+        connected:
+          type: boolean
+        expiresAt:
+          type: string
+          format: date-time
+          nullable: true
+        scopes:
+          type: array
+          items:
+            type: string
+        updatedAt:
+          type: string
+          format: date-time
+          nullable: true
+        metadata:
+          type: object
+          nullable: true
+          additionalProperties: true
+      required: [provider, ownerKey, connected, scopes]
+
+    IntegrationRefreshResponse:
+      allOf:
+        - $ref: "#/components/schemas/IntegrationStatusResponse"
+        - type: object
+          properties:
+            refreshed:
+              type: boolean
+            accessTokenAvailable:
+              type: boolean
+          required: [refreshed, accessTokenAvailable]
+
+    IntuitCheckoutSessionRequest:
+      type: object
+      required: [appointmentId]
+      properties:
+        appointmentId:
+          type: string
+          format: uuid
+        tipAmount:
+          type: number
+          minimum: 0
+        currency:
+          type: string
+          minLength: 3
+          maxLength: 3
+          example: USD
+
+    IntuitCheckoutSessionResponse:
+      type: object
+      properties:
+        provider:
+          type: string
+          example: intuit
+        externalPaymentId:
+          type: string
+        checkoutUrl:
+          type: string
+          format: uri
+        amount:
+          type: number
+        currency:
+          type: string
+        status:
+          type: string
+      required: [provider, externalPaymentId, checkoutUrl, amount, currency, status]
+
+    IntuitWebhookProcessResponse:
+      type: object
+      properties:
+        accepted:
+          type: boolean
+        duplicate:
+          type: boolean
+        eventId:
+          type: string
+        status:
+          type: string
+      required: [accepted, duplicate, eventId, status]
 
     AvailabilitySlotsResponse:
       type: object


### PR DESCRIPTION
## Summary
- Finalize API contracts and developer assets for OAuth + Intuit payment flows.
- Update OpenAPI, Postman, README, and frontend API starter to match implemented backend behavior.
## Changes
- Updated `openapi.yaml` with OAuth/integration/payment/webhook endpoints and schemas.
- Updated `docs/postman_collection.json` with new request flows and variables.
- Updated `docs/frontend-api-client.ts` with OAuth/integration/payment methods.
- Updated README/API docs for OAuth-first calendar setup and Intuit flow details.
- Removed stale service-account-only framing in docs.
## Why
Ensures frontend/integration teams can use the new backend capabilities immediately and consistently.
## Test Plan
- `npx tsc --noEmit`
- Validate Postman JSON parses
- Run focused regressions:
  - `oauth.routes.test.ts`
  - `integration.routes.test.ts`
  - `payment.webhook.test.ts`
  - `appointment.test.ts`