### PR TITLE
feat: harden pre-frontend security for payments and PII

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -404,20 +404,27 @@ Supported providers:
 - `google_calendar`
 - `intuit`
 
-## 14) Intuit Payment Flow (v1)
+## 14) Intuit Payment Flow (hardened)
 
 Checkout creation:
 
 - `POST /api/payments/intuit/checkout-session`
+- requires booking-scoped token in `x-booking-token` (or `bookingToken` body field)
 - creates a `PaymentTransaction` with `pending` status
 - stores `paymentProvider=intuit` and `paymentExternalId` on the appointment
 
 Webhook processing:
 
 - `POST /api/webhooks/intuit`
-- optional shared-secret protection via `INTUIT_WEBHOOK_SECRET` and `x-intuit-webhook-secret` header
-- deduplicates events with `IntegrationWebhookEvent` (`provider + eventExternalId`)
-- on succeeded events, marks appointment as paid/confirmed and updates related payment transaction records
+- requires signed webhook headers (`intuit-signature`, `intuit-timestamp`) when `INTUIT_WEBHOOK_SECRET` is configured
+- enforces replay-window checks (`INTUIT_WEBHOOK_MAX_AGE_SECONDS`, default 300s)
+- blocks replayed signatures with `WebhookReplayGuard` in addition to event-id dedupe
+- accepts only allowlisted success events (`INTUIT_SUCCESS_EVENT_TYPES`)
+- verifies strict payment integrity before confirmation:
+  - `externalPaymentId` maps to pending transaction
+  - amount/currency must match expected transaction values
+  - realm/account mismatch is rejected when available
+- on mismatch/replay/signature errors, rejects webhook and emits security audit + alert records
 
 Server-trusted confirmation:
 
@@ -428,4 +435,24 @@ Server-trusted confirmation:
 - Prisma schema + seed:
   - `prisma/schema.prisma`
   - `prisma/seed.ts`
+
+Route access hardening:
+
+- public:
+  - `POST /api/appointments`
+  - `GET /api/appointments/available`
+  - `POST /api/contact`
+- admin-only:
+  - `GET /api/appointments`
+  - `GET /api/appointments/:id`
+  - `PUT /api/appointments/:id`
+  - `DELETE /api/appointments/:id`
+  - `GET /api/contact`
+  - `DELETE /api/contact/:id`
+
+Security operations:
+
+- structured security audit records are persisted in `SecurityAuditEvent`
+- retention cleanup endpoint:
+  - `POST /api/admin/security/retention/run` (admin auth required)
 

--- a/README.md
+++ b/README.md
@@ -79,20 +79,51 @@ INTUIT_PAYMENT_MODE=mock
 # optional checkout redirect base (mock/demo mode)
 INTUIT_CHECKOUT_BASE_URL=https://sandbox.intuit.com/mock-checkout
 
-# webhook shared secret (optional but recommended)
+# webhook signature secret (required in production)
 INTUIT_WEBHOOK_SECRET=replace-me
+INTUIT_WEBHOOK_MAX_AGE_SECONDS=300
+# optional allowlist override:
+# INTUIT_SUCCESS_EVENT_TYPES=payment.succeeded,payment.success,charge.succeeded
+
+# checkout token signing (required for /payments/intuit/checkout-session)
+BOOKING_TOKEN_SECRET=replace-me
 
 # server-side appointment confirmation secret (for /appointments/:id/confirm)
 PAYMENT_CONFIRMATION_SECRET=replace-me
 
 # tests only: enforce confirmation auth even in NODE_ENV=test
 # PAYMENT_CONFIRMATION_ENFORCE_IN_TEST=false
+
+# security alert destination (defaults to BUSINESS_OWNER_EMAIL)
+# SECURITY_ALERT_EMAIL=security@example.com
 ```
 
 Payment endpoints:
 
-- `POST /api/payments/intuit/checkout-session`
-- `POST /api/webhooks/intuit`
+- `POST /api/payments/intuit/checkout-session` (requires `x-booking-token`)
+- `POST /api/webhooks/intuit` (requires `intuit-signature` + `intuit-timestamp`)
+
+Public route hardening:
+
+- public: `POST /api/appointments`, `GET /api/appointments/available`, `POST /api/contact`
+- admin-only: appointment list/detail/update/delete and contact list/delete
+
+Optional bot mitigation for public create routes:
+
+```env
+# enable CAPTCHA checks for POST /api/appointments and POST /api/contact
+CAPTCHA_SECRET=...
+# optional: turnstile (default) or hcaptcha
+# CAPTCHA_PROVIDER=turnstile
+# CAPTCHA_VERIFY_URL=https://challenges.cloudflare.com/turnstile/v0/siteverify
+```
+
+Distributed abuse controls:
+
+```env
+# enables Redis-backed rate limiting when set
+REDIS_URL=redis://localhost:6379
+```
 
 ## Reminder Dispatch Automation
 
@@ -113,6 +144,22 @@ REMINDER_ALERT_EMAIL=owner@example.com
 Manual dispatch endpoint (admin-protected) still exists:
 
 - `POST /api/admin/email/reminders/dispatch`
+
+## Data Retention
+
+Run cleanup manually (admin-protected):
+
+- `POST /api/admin/security/retention/run`
+
+Optional scheduler:
+
+```env
+ENABLE_DATA_RETENTION_SCHEDULER=true
+DATA_RETENTION_INTERVAL_HOURS=24
+RETENTION_CONTACT_REQUEST_DAYS=90
+RETENTION_WEBHOOK_EVENT_DAYS=90
+RETENTION_SECURITY_AUDIT_DAYS=180
+```
 
 ## Test Commands
 

--- a/docs/frontend-api-client.ts
+++ b/docs/frontend-api-client.ts
@@ -42,6 +42,7 @@ export interface Appointment {
   tipAmount?: number | null;
   paymentProvider?: string | null;
   paymentExternalId?: string | null;
+  checkoutToken?: string | null;
   service?: Service;
 }
 
@@ -202,21 +203,24 @@ export class MomsWebsiteApiClient {
     return this.request('/appointments', 'POST', input);
   }
 
+  // Admin-only appointment listing
   listAppointments(filters?: { dateFrom?: string; dateTo?: string; serviceId?: string }): Promise<Appointment[]> {
     const params = new URLSearchParams();
     if (filters?.dateFrom) params.set('dateFrom', filters.dateFrom);
     if (filters?.dateTo) params.set('dateTo', filters.dateTo);
     if (filters?.serviceId) params.set('serviceId', filters.serviceId);
     const suffix = params.toString() ? `?${params.toString()}` : '';
-    return this.request(`/appointments${suffix}`);
+    return this.request(`/appointments${suffix}`, 'GET', undefined, true);
   }
 
+  // Admin-only appointment detail
   getAppointmentById(appointmentId: string): Promise<Appointment> {
-    return this.request(`/appointments/${appointmentId}`);
+    return this.request(`/appointments/${appointmentId}`, 'GET', undefined, true);
   }
 
+  // Admin-only appointment updates
   updateAppointment(appointmentId: string, input: AppointmentUpdateInput): Promise<Appointment> {
-    return this.request(`/appointments/${appointmentId}`, 'PUT', input);
+    return this.request(`/appointments/${appointmentId}`, 'PUT', input, true);
   }
 
   confirmAppointment(appointmentId: string, paymentConfirmationSecret?: string): Promise<Appointment> {
@@ -230,8 +234,9 @@ export class MomsWebsiteApiClient {
     }, false, headers);
   }
 
+  // Admin-only appointment delete
   deleteAppointment(appointmentId: string): Promise<void> {
-    return this.request(`/appointments/${appointmentId}`, 'DELETE');
+    return this.request(`/appointments/${appointmentId}`, 'DELETE', undefined, true);
   }
 
   getAvailableSlots(serviceId: string, date: string): Promise<{
@@ -251,12 +256,14 @@ export class MomsWebsiteApiClient {
     return this.request('/contact', 'POST', input);
   }
 
+  // Admin-only contact listing
   listContactRequests(): Promise<ContactRequest[]> {
-    return this.request('/contact');
+    return this.request('/contact', 'GET', undefined, true);
   }
 
+  // Admin-only contact deletion
   deleteContactRequest(contactId: string): Promise<void> {
-    return this.request(`/contact/${contactId}`, 'DELETE');
+    return this.request(`/contact/${contactId}`, 'DELETE', undefined, true);
   }
 
   // Public content
@@ -414,8 +421,23 @@ export class MomsWebsiteApiClient {
   }
 
   // Payments
-  createIntuitCheckoutSession(input: { appointmentId: string; tipAmount?: number; currency?: string }): Promise<CheckoutSession> {
-    return this.request('/payments/intuit/checkout-session', 'POST', input);
+  createIntuitCheckoutSession(input: {
+    appointmentId: string;
+    bookingToken: string;
+    tipAmount?: number;
+    currency?: string;
+  }): Promise<CheckoutSession> {
+    return this.request(
+      '/payments/intuit/checkout-session',
+      'POST',
+      {
+        appointmentId: input.appointmentId,
+        tipAmount: input.tipAmount,
+        currency: input.currency,
+      },
+      false,
+      { 'x-booking-token': input.bookingToken }
+    );
   }
 }
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -270,6 +270,13 @@ paths:
       tags: [Payments]
       summary: Create Intuit checkout session for appointment
       operationId: createIntuitCheckoutSession
+      parameters:
+        - in: header
+          name: x-booking-token
+          required: false
+          schema:
+            type: string
+          description: Booking-scoped token required when not supplied in request body.
       requestBody:
         required: true
         content:
@@ -285,6 +292,12 @@ paths:
                 $ref: "#/components/schemas/IntuitCheckoutSessionResponse"
         "400":
           $ref: "#/components/responses/BadRequest"
+        "401":
+          description: Missing or invalid booking token
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "404":
           description: Appointment not found
           content:
@@ -299,6 +312,17 @@ paths:
       tags: [Webhooks]
       summary: Process Intuit payment webhook
       operationId: processIntuitWebhook
+      parameters:
+        - in: header
+          name: intuit-signature
+          required: true
+          schema:
+            type: string
+        - in: header
+          name: intuit-timestamp
+          required: true
+          schema:
+            type: string
       requestBody:
         required: true
         content:
@@ -315,6 +339,12 @@ paths:
                 $ref: "#/components/schemas/IntuitWebhookProcessResponse"
         "401":
           description: Unauthorized webhook signature
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "409":
+          description: Replayed webhook signature
           content:
             application/json:
               schema:
@@ -1610,6 +1640,9 @@ components:
         appointmentId:
           type: string
           format: uuid
+        bookingToken:
+          type: string
+          description: Booking-scoped access token. Can be supplied via x-booking-token header instead.
         tipAmount:
           type: number
           minimum: 0

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,9 +22,11 @@
         "googleapis": "^171.4.0",
         "helmet": "^8.1.0",
         "hpp": "^0.2.3",
+        "ioredis": "^5.10.1",
         "joi": "^17.13.3",
         "morgan": "^1.10.0",
-        "nodemailer": "^7.0.12"
+        "nodemailer": "^7.0.12",
+        "rate-limit-redis": "^4.3.1"
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",
@@ -1800,6 +1802,12 @@
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
       }
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.1.tgz",
+      "integrity": "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==",
+      "license": "MIT"
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -3862,6 +3870,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -4107,6 +4124,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/depd": {
@@ -5329,6 +5355,53 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ioredis": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.1.tgz",
+      "integrity": "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "1.5.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
+    "node_modules/ioredis/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ioredis/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -6287,6 +6360,18 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -7016,6 +7101,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/rate-limit-redis": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/rate-limit-redis/-/rate-limit-redis-4.3.1.tgz",
+      "integrity": "sha512-+a1zU8+D7L8siDK9jb14refQXz60vq427VuiplgnaLk9B2LnvGe/APLTfhwb4uNIL7eWVknh8GnRp/unCj+lMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "peerDependencies": {
+        "express-rate-limit": ">= 6"
+      }
+    },
     "node_modules/raw-body": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
@@ -7037,6 +7134,27 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -7392,6 +7510,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -26,9 +26,11 @@
     "googleapis": "^171.4.0",
     "helmet": "^8.1.0",
     "hpp": "^0.2.3",
+    "ioredis": "^5.10.1",
     "joi": "^17.13.3",
     "morgan": "^1.10.0",
-    "nodemailer": "^7.0.12"
+    "nodemailer": "^7.0.12",
+    "rate-limit-redis": "^4.3.1"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",

--- a/prisma/migrations/20260429143000_security_hardening_foundation/migration.sql
+++ b/prisma/migrations/20260429143000_security_hardening_foundation/migration.sql
@@ -1,0 +1,40 @@
+-- CreateTable
+CREATE TABLE "WebhookReplayGuard" (
+    "id" TEXT NOT NULL,
+    "provider" TEXT NOT NULL,
+    "signatureHash" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "WebhookReplayGuard_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "SecurityAuditEvent" (
+    "id" TEXT NOT NULL,
+    "eventType" TEXT NOT NULL,
+    "outcome" TEXT NOT NULL,
+    "severity" TEXT NOT NULL,
+    "provider" TEXT,
+    "appointmentId" TEXT,
+    "paymentTransactionId" TEXT,
+    "metadata" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "SecurityAuditEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "WebhookReplayGuard_provider_signatureHash_key" ON "WebhookReplayGuard"("provider", "signatureHash");
+
+-- CreateIndex
+CREATE INDEX "WebhookReplayGuard_expiresAt_idx" ON "WebhookReplayGuard"("expiresAt");
+
+-- CreateIndex
+CREATE INDEX "SecurityAuditEvent_eventType_createdAt_idx" ON "SecurityAuditEvent"("eventType", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "SecurityAuditEvent_severity_createdAt_idx" ON "SecurityAuditEvent"("severity", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "SecurityAuditEvent_provider_createdAt_idx" ON "SecurityAuditEvent"("provider", "createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -193,3 +193,30 @@ model PaymentTransaction {
   @@index([provider, status])
   @@index([appointmentId, provider])
 }
+
+model WebhookReplayGuard {
+  id            String   @id @default(uuid())
+  provider      String
+  signatureHash String
+  expiresAt     DateTime
+  createdAt     DateTime @default(now())
+
+  @@unique([provider, signatureHash])
+  @@index([expiresAt])
+}
+
+model SecurityAuditEvent {
+  id                   String   @id @default(uuid())
+  eventType            String
+  outcome              String
+  severity             String
+  provider             String?
+  appointmentId        String?
+  paymentTransactionId String?
+  metadata             Json?
+  createdAt            DateTime @default(now())
+
+  @@index([eventType, createdAt])
+  @@index([severity, createdAt])
+  @@index([provider, createdAt])
+}

--- a/src/__tests__/appointment.email.test.ts
+++ b/src/__tests__/appointment.email.test.ts
@@ -13,6 +13,7 @@ import { getValidMstBookingDate } from './utils/scheduling';
 
 const prisma = new PrismaClient();
 const mockSendEmail = sendEmail as jest.MockedFunction<typeof sendEmail>;
+const ADMIN_KEY = process.env.ADMIN_KEY || 'test-admin-key';
 
 describe('Appointment Email Integration', () => {
   const testService = {
@@ -150,6 +151,7 @@ describe('Appointment Email Integration', () => {
 
       await request(app)
         .put(`/api/appointments/${appointment.id}`)
+        .set('x-admin-key', ADMIN_KEY)
         .send({
           date: newDate,
         })
@@ -180,6 +182,7 @@ describe('Appointment Email Integration', () => {
       const newDate = getValidMstBookingDate(11, 2).toISOString();
       await request(app)
         .put(`/api/appointments/${appointment.id}`)
+        .set('x-admin-key', ADMIN_KEY)
         .send({ date: newDate })
         .expect(200);
 
@@ -209,6 +212,7 @@ describe('Appointment Email Integration', () => {
 
       await request(app)
         .put(`/api/appointments/${appointment.id}`)
+        .set('x-admin-key', ADMIN_KEY)
         .send({
           clientFirstName: 'Jane', // Only updating name, not date
         })
@@ -235,6 +239,7 @@ describe('Appointment Email Integration', () => {
 
       await request(app)
         .put(`/api/appointments/${appointment.id}`)
+        .set('x-admin-key', ADMIN_KEY)
         .send({ date: newDate })
         .expect(200);
 
@@ -322,6 +327,7 @@ describe('Appointment Email Integration', () => {
 
       await request(app)
         .delete(`/api/appointments/${appointment.id}`)
+        .set('x-admin-key', ADMIN_KEY)
         .expect(204);
 
       await new Promise((resolve) => setTimeout(resolve, 500));
@@ -346,6 +352,7 @@ describe('Appointment Email Integration', () => {
 
       await request(app)
         .delete(`/api/appointments/${appointment.id}`)
+        .set('x-admin-key', ADMIN_KEY)
         .expect(204);
 
       await new Promise((resolve) => setTimeout(resolve, 500));
@@ -374,6 +381,7 @@ describe('Appointment Email Integration', () => {
 
       await request(app)
         .delete(`/api/appointments/${appointment.id}`)
+        .set('x-admin-key', ADMIN_KEY)
         .expect(204);
 
       await new Promise((resolve) => setTimeout(resolve, 500));
@@ -405,6 +413,7 @@ describe('Appointment Email Integration', () => {
       // Should still delete the appointment
       await request(app)
         .delete(`/api/appointments/${appointment.id}`)
+        .set('x-admin-key', ADMIN_KEY)
         .expect(204);
     });
   });

--- a/src/__tests__/appointment.test.ts
+++ b/src/__tests__/appointment.test.ts
@@ -5,6 +5,7 @@ import '../__tests__/setup';
 import { getValidMstBookingDate } from './utils/scheduling';
 
 const prisma = new PrismaClient();
+const ADMIN_KEY = process.env.ADMIN_KEY || 'test-admin-key';
 
 describe('Appointment Routes', () => {
   // Test data
@@ -117,6 +118,7 @@ describe('Appointment Routes', () => {
 
       const response = await request(app)
         .get('/api/appointments')
+        .set('x-admin-key', ADMIN_KEY)
         .expect(200);
 
       expect(Array.isArray(response.body)).toBe(true);
@@ -147,6 +149,7 @@ describe('Appointment Routes', () => {
 
       const response = await request(app)
         .get('/api/appointments')
+        .set('x-admin-key', ADMIN_KEY)
         .query({
           dateFrom: firstDate.toISOString(),
           dateTo: new Date(firstDate.getTime() + 2 * 60 * 60 * 1000).toISOString(),
@@ -185,6 +188,7 @@ describe('Appointment Routes', () => {
 
       const response = await request(app)
         .get(`/api/appointments/${createdAppointment.id}`)
+        .set('x-admin-key', ADMIN_KEY)
         .expect(200);
 
       expect(response.body.id).toBe(createdAppointment.id);
@@ -194,6 +198,7 @@ describe('Appointment Routes', () => {
     it('should return 404 if appointment not found', async () => {
       const response = await request(app)
         .get('/api/appointments/non-existent-id')
+        .set('x-admin-key', ADMIN_KEY)
         .expect(404);
 
       expect(response.body).toHaveProperty('error');
@@ -220,6 +225,7 @@ describe('Appointment Routes', () => {
 
       const response = await request(app)
         .put(`/api/appointments/${createdAppointment.id}`)
+        .set('x-admin-key', ADMIN_KEY)
         .send(updatedData)
         .expect(200);
 
@@ -262,6 +268,7 @@ describe('Appointment Routes', () => {
 
       await request(app)
         .delete(`/api/appointments/${createdAppointment.id}`)
+        .set('x-admin-key', ADMIN_KEY)
         .expect(204);
 
       // Verify the appointment is deleted
@@ -283,6 +290,7 @@ describe('Appointment Routes', () => {
 
       const response = await request(app)
         .delete(`/api/appointments/${soonAppointment.id}`)
+        .set('x-admin-key', ADMIN_KEY)
         .expect(400);
 
       expect(response.body.error).toContain('cancelled at least 24 hours in advance');

--- a/src/__tests__/contactRequest.test.ts
+++ b/src/__tests__/contactRequest.test.ts
@@ -4,6 +4,7 @@ import { PrismaClient } from '@prisma/client';
 import '../__tests__/setup';
 
 const prisma = new PrismaClient();
+const ADMIN_KEY = process.env.ADMIN_KEY || 'test-admin-key';
 
 describe('Contact Request Routes', () => {
   //Test data
@@ -27,7 +28,9 @@ describe('Contact Request Routes', () => {
       await prisma.contactRequest.create({
         data: testContactRequest
       });
-      const response = await request(app).get('/api/contact');
+      const response = await request(app)
+        .get('/api/contact')
+        .set('x-admin-key', ADMIN_KEY);
       expect(response.status).toBe(200);
       expect(response.body).toBeInstanceOf(Array);
     });
@@ -39,7 +42,9 @@ describe('Contact Request Routes', () => {
         data: testContactRequest
       });
       
-      const response = await request(app).delete(`/api/contact/${contactRequest.id}`);
+      const response = await request(app)
+        .delete(`/api/contact/${contactRequest.id}`)
+        .set('x-admin-key', ADMIN_KEY);
       expect(response.status).toBe(204);
     });
   });

--- a/src/__tests__/payment.webhook.test.ts
+++ b/src/__tests__/payment.webhook.test.ts
@@ -4,14 +4,27 @@ import { app } from '../index';
 import '../__tests__/setup';
 import { getValidMstBookingDate } from './utils/scheduling';
 import axios from 'axios';
+import crypto from 'crypto';
 import * as emailService from '../services/email.service';
 import * as oauthService from '../services/oauth/oauth.service';
+import { createBookingAccessToken } from '../services/booking-token.service';
 
 const prisma = new PrismaClient();
+
+const createIntuitWebhookHeaders = (payload: Record<string, unknown>, secret: string, timestamp: number) => {
+  const raw = JSON.stringify(payload);
+  const base = `${timestamp}.${raw}`;
+  const signature = crypto.createHmac('sha256', secret).update(base, 'utf8').digest('base64');
+  return {
+    'intuit-signature': signature,
+    'intuit-timestamp': String(timestamp),
+  };
+};
 
 describe('Payment + Webhook Flow', () => {
   beforeEach(() => {
     jest.spyOn(emailService, 'sendEmail').mockResolvedValue(undefined);
+    process.env.BOOKING_TOKEN_SECRET = 'test-booking-token-secret';
   });
 
   afterEach(() => {
@@ -19,6 +32,8 @@ describe('Payment + Webhook Flow', () => {
     delete process.env.INTUIT_WEBHOOK_SECRET;
     delete process.env.INTUIT_PAYMENT_MODE;
     delete process.env.INTUIT_PAYMENTS_CREATE_URL;
+    delete process.env.BOOKING_TOKEN_SECRET;
+    delete process.env.INTUIT_SUCCESS_EVENT_TYPES;
   });
 
   it('should create an Intuit checkout session and persist payment transaction', async () => {
@@ -51,6 +66,10 @@ describe('Payment + Webhook Flow', () => {
 
     const response = await request(app)
       .post('/api/payments/intuit/checkout-session')
+      .set(
+        'x-booking-token',
+        createBookingAccessToken({ appointmentId: appointment.id, email: appointment.email })
+      )
       .send({ appointmentId: appointment.id, tipAmount: 20 })
       .expect(201);
 
@@ -63,6 +82,40 @@ describe('Payment + Webhook Flow', () => {
     });
     expect(tx).not.toBeNull();
     expect(tx?.status).toBe('pending');
+  });
+
+  it('rejects checkout session creation without booking token', async () => {
+    const client = await prisma.client.create({
+      data: {
+        name: 'No Token Client',
+        aboutMe: 'About text',
+        email: 'notoken-owner@example.com',
+      },
+    });
+    const service = await prisma.service.create({
+      data: {
+        title: 'No Token Service',
+        description: 'Service description text',
+        price: 120,
+        isPublished: true,
+        clientId: client.id,
+      },
+    });
+    const appointment = await prisma.appointment.create({
+      data: {
+        clientFirstName: 'No',
+        clientLastName: 'Token',
+        email: 'no-token@example.com',
+        phone: '+15555551000',
+        date: getValidMstBookingDate(10, 2),
+        serviceId: service.id,
+      },
+    });
+
+    await request(app)
+      .post('/api/payments/intuit/checkout-session')
+      .send({ appointmentId: appointment.id })
+      .expect(401);
   });
 
   it('should create a live-mode Intuit checkout session with OAuth token', async () => {
@@ -105,6 +158,10 @@ describe('Payment + Webhook Flow', () => {
 
     const response = await request(app)
       .post('/api/payments/intuit/checkout-session')
+      .set(
+        'x-booking-token',
+        createBookingAccessToken({ appointmentId: appointment.id, email: appointment.email })
+      )
       .send({ appointmentId: appointment.id, tipAmount: 15 })
       .expect(201);
 
@@ -145,6 +202,10 @@ describe('Payment + Webhook Flow', () => {
 
     const checkout = await request(app)
       .post('/api/payments/intuit/checkout-session')
+      .set(
+        'x-booking-token',
+        createBookingAccessToken({ appointmentId: appointment.id, email: appointment.email })
+      )
       .send({ appointmentId: appointment.id })
       .expect(201);
 
@@ -156,23 +217,37 @@ describe('Payment + Webhook Flow', () => {
       eventType: 'payment.succeeded',
       paymentId,
       appointmentId: appointment.id,
+      amount: 120,
+      currency: 'USD',
       metadata: {
         appointmentId: appointment.id,
       },
     };
 
+    const firstHeaders = createIntuitWebhookHeaders(
+      payload,
+      'test-secret',
+      Math.floor(Date.now() / 1000)
+    );
     const first = await request(app)
       .post('/api/webhooks/intuit')
-      .set('x-intuit-webhook-secret', 'test-secret')
+      .set('intuit-signature', firstHeaders['intuit-signature'])
+      .set('intuit-timestamp', firstHeaders['intuit-timestamp'])
       .send(payload)
       .expect(200);
 
     expect(first.body.duplicate).toBe(false);
     expect(first.body.status).toBe('confirmed');
 
+    const secondHeaders = createIntuitWebhookHeaders(
+      payload,
+      'test-secret',
+      Math.floor(Date.now() / 1000) + 1
+    );
     const second = await request(app)
       .post('/api/webhooks/intuit')
-      .set('x-intuit-webhook-secret', 'test-secret')
+      .set('intuit-signature', secondHeaders['intuit-signature'])
+      .set('intuit-timestamp', secondHeaders['intuit-timestamp'])
       .send(payload)
       .expect(200);
 
@@ -188,5 +263,69 @@ describe('Payment + Webhook Flow', () => {
       expect.stringContaining('Payment received:'),
       expect.any(String)
     );
+  });
+
+  it('rejects replayed webhook signatures', async () => {
+    const client = await prisma.client.create({
+      data: {
+        name: 'Replay Client',
+        aboutMe: 'About text',
+        email: 'replay-owner@example.com',
+      },
+    });
+    const service = await prisma.service.create({
+      data: {
+        title: 'Replay Service',
+        description: 'Service description text',
+        price: 80,
+        isPublished: true,
+        clientId: client.id,
+      },
+    });
+    const appointment = await prisma.appointment.create({
+      data: {
+        clientFirstName: 'Replay',
+        clientLastName: 'Target',
+        email: 'replay-user@example.com',
+        phone: '+15555550001',
+        date: getValidMstBookingDate(11, 2),
+        serviceId: service.id,
+      },
+    });
+
+    const checkout = await request(app)
+      .post('/api/payments/intuit/checkout-session')
+      .set(
+        'x-booking-token',
+        createBookingAccessToken({ appointmentId: appointment.id, email: appointment.email })
+      )
+      .send({ appointmentId: appointment.id })
+      .expect(201);
+
+    process.env.INTUIT_WEBHOOK_SECRET = 'test-secret';
+    const timestamp = Math.floor(Date.now() / 1000);
+    const payload = {
+      eventId: 'evt-replay-1',
+      eventType: 'payment.succeeded',
+      paymentId: checkout.body.externalPaymentId,
+      appointmentId: appointment.id,
+      amount: 80,
+      currency: 'USD',
+    };
+    const headers = createIntuitWebhookHeaders(payload, 'test-secret', timestamp);
+
+    await request(app)
+      .post('/api/webhooks/intuit')
+      .set('intuit-signature', headers['intuit-signature'])
+      .set('intuit-timestamp', headers['intuit-timestamp'])
+      .send(payload)
+      .expect(200);
+
+    await request(app)
+      .post('/api/webhooks/intuit')
+      .set('intuit-signature', headers['intuit-signature'])
+      .set('intuit-timestamp', headers['intuit-timestamp'])
+      .send(payload)
+      .expect(409);
   });
 });

--- a/src/__tests__/security.test.ts
+++ b/src/__tests__/security.test.ts
@@ -95,12 +95,12 @@ describe('Security Measures', () => {
   });
 
   describe('Public vs Protected Routes', () => {
-    it('should allow public access to appointments', async () => {
+    it('should require admin auth for appointment listings', async () => {
       const response = await request(app)
         .get('/api/appointments')
-        .expect(200);
+        .expect(401);
 
-      expect(response.status).toBe(200);
+      expect(response.status).toBe(401);
     });
 
     it('should allow public access to services', async () => {
@@ -114,6 +114,14 @@ describe('Security Measures', () => {
     it('should require admin key for protected routes', async () => {
       const response = await request(app)
         .get('/api/services/admin/all')
+        .expect(401);
+
+      expect(response.status).toBe(401);
+    });
+
+    it('should require admin key for contact request listings', async () => {
+      const response = await request(app)
+        .get('/api/contact')
         .expect(401);
 
       expect(response.status).toBe(401);

--- a/src/__tests__/smoke.booking-payment-reminder.test.ts
+++ b/src/__tests__/smoke.booking-payment-reminder.test.ts
@@ -1,5 +1,6 @@
 import request from 'supertest';
 import { PrismaClient } from '@prisma/client';
+import crypto from 'crypto';
 import { app } from '../index';
 import '../__tests__/setup';
 import { getValidMstBookingDate } from './utils/scheduling';
@@ -10,11 +11,25 @@ const prisma = new PrismaClient();
 describe('Smoke E2E: book -> checkout -> webhook -> reminder queued', () => {
   beforeEach(() => {
     jest.spyOn(emailService, 'sendEmail').mockResolvedValue(undefined);
+    process.env.BOOKING_TOKEN_SECRET = 'smoke-booking-token-secret';
   });
+
+  const createWebhookHeaders = (payload: Record<string, unknown>, secret: string, timestamp: number) => {
+    const raw = JSON.stringify(payload);
+    const signature = crypto
+      .createHmac('sha256', secret)
+      .update(`${timestamp}.${raw}`, 'utf8')
+      .digest('base64');
+    return {
+      'intuit-signature': signature,
+      'intuit-timestamp': String(timestamp),
+    };
+  };
 
   afterEach(() => {
     jest.restoreAllMocks();
     delete process.env.INTUIT_WEBHOOK_SECRET;
+    delete process.env.BOOKING_TOKEN_SECRET;
   });
 
   it('runs complete happy path and keeps reminder job queued', async () => {
@@ -49,7 +64,9 @@ describe('Smoke E2E: book -> checkout -> webhook -> reminder queued', () => {
 
     expect(booking.status).toBe(201);
     const appointmentId = booking.body.id as string;
+    const bookingToken = booking.body.checkoutToken as string;
     expect(appointmentId).toBeTruthy();
+    expect(bookingToken).toBeTruthy();
 
     const reminder = await prisma.reminderJob.findFirst({
       where: { appointmentId, status: 'pending' },
@@ -58,21 +75,27 @@ describe('Smoke E2E: book -> checkout -> webhook -> reminder queued', () => {
 
     const checkout = await request(app)
       .post('/api/payments/intuit/checkout-session')
+      .set('x-booking-token', bookingToken)
       .send({ appointmentId })
       .expect(201);
     const paymentId = checkout.body.externalPaymentId as string;
     expect(paymentId).toBeTruthy();
 
     process.env.INTUIT_WEBHOOK_SECRET = 'smoke-secret';
+    const payload = {
+      eventId: 'smoke-evt-1',
+      eventType: 'payment.succeeded',
+      paymentId,
+      appointmentId,
+      amount: 140,
+      currency: 'USD',
+    };
+    const headers = createWebhookHeaders(payload, 'smoke-secret', Math.floor(Date.now() / 1000));
     await request(app)
       .post('/api/webhooks/intuit')
-      .set('x-intuit-webhook-secret', 'smoke-secret')
-      .send({
-        eventId: 'smoke-evt-1',
-        eventType: 'payment.succeeded',
-        paymentId,
-        appointmentId,
-      })
+      .set('intuit-signature', headers['intuit-signature'])
+      .set('intuit-timestamp', headers['intuit-timestamp'])
+      .send(payload)
       .expect(200);
 
     const updatedAppointment = await prisma.appointment.findUnique({ where: { id: appointmentId } });

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,18 @@ const corsOptions = {
     ? process.env.FRONTEND_URL 
     : ['http://localhost:3000', 'http://localhost:5001'],
   methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
-  allowedHeaders: ['Content-Type', 'Authorization', 'x-admin-key'],
+  allowedHeaders: [
+    'Content-Type',
+    'Authorization',
+    'x-admin-key',
+    'x-payment-confirmation-secret',
+    'x-captcha-token',
+    'x-booking-token',
+    'x-intuit-signature',
+    'x-intuit-timestamp',
+    'intuit-signature',
+    'intuit-timestamp',
+  ],
   credentials: true,
   maxAge: 86400 // 24 hours
 };
@@ -72,6 +83,7 @@ app.use(helmet({
 app.use(morgan(process.env.NODE_ENV === 'production' ? 'combined' : 'dev'));
 
 // Body parsing
+app.use('/api/webhooks/intuit', express.raw({ type: 'application/json', limit: '100kb' }));
 app.use(express.json({ limit: '10kb' })); // Limit body size
 app.use(bodyParser.urlencoded({ extended: true, limit: '10kb' }));
 app.use(cookieParser());

--- a/src/jobs/reminder.dispatcher.ts
+++ b/src/jobs/reminder.dispatcher.ts
@@ -1,7 +1,9 @@
 import { dispatchDueAppointmentReminders } from '../services/reminder.service';
 import { sendEmail } from '../services/email.service';
+import { runDataRetentionCleanup } from '../services/data-retention.service';
 
 let reminderInterval: NodeJS.Timeout | null = null;
+let retentionInterval: NodeJS.Timeout | null = null;
 
 const getAlertRecipient = (): string | null =>
   process.env.REMINDER_ALERT_EMAIL || process.env.BUSINESS_OWNER_EMAIL || null;
@@ -95,11 +97,30 @@ export const startReminderDispatchScheduler = (): void => {
       intervalMinutes === 1 ? '' : 's'
     }).`
   );
+
+  if (process.env.ENABLE_DATA_RETENTION_SCHEDULER === 'true' && !retentionInterval) {
+    const retentionIntervalHours = Math.max(
+      1,
+      parseInt(process.env.DATA_RETENTION_INTERVAL_HOURS || '24', 10)
+    );
+    void runDataRetentionCleanup().catch((error) => {
+      console.error('Initial data retention cleanup failed:', error);
+    });
+    retentionInterval = setInterval(() => {
+      void runDataRetentionCleanup().catch((error) => {
+        console.error('Scheduled data retention cleanup failed:', error);
+      });
+    }, retentionIntervalHours * 60 * 60 * 1000);
+  }
 };
 
 export const stopReminderDispatchScheduler = (): void => {
   if (reminderInterval) {
     clearInterval(reminderInterval);
     reminderInterval = null;
+  }
+  if (retentionInterval) {
+    clearInterval(retentionInterval);
+    retentionInterval = null;
   }
 };

--- a/src/middleware/captcha.ts
+++ b/src/middleware/captcha.ts
@@ -1,0 +1,74 @@
+import { Request, Response, NextFunction } from 'express';
+
+const getTokenFromRequest = (req: Request): string | null => {
+  const headerValue = req.headers['x-captcha-token'];
+  if (typeof headerValue === 'string' && headerValue.trim()) {
+    return headerValue;
+  }
+  const bodyToken = req.body?.captchaToken;
+  if (typeof bodyToken === 'string' && bodyToken.trim()) {
+    return bodyToken;
+  }
+  return null;
+};
+
+const verifyCaptchaToken = async (token: string, remoteIp?: string): Promise<boolean> => {
+  const secret = process.env.CAPTCHA_SECRET;
+  if (!secret) {
+    return true;
+  }
+
+  const provider = process.env.CAPTCHA_PROVIDER || 'turnstile';
+  const verifyUrl =
+    process.env.CAPTCHA_VERIFY_URL ||
+    (provider === 'hcaptcha'
+      ? 'https://hcaptcha.com/siteverify'
+      : 'https://challenges.cloudflare.com/turnstile/v0/siteverify');
+
+  const form = new URLSearchParams();
+  form.set('secret', secret);
+  form.set('response', token);
+  if (remoteIp) {
+    form.set('remoteip', remoteIp);
+  }
+
+  const response = await fetch(verifyUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: form.toString(),
+  });
+  if (!response.ok) {
+    return false;
+  }
+
+  const data = (await response.json()) as { success?: boolean };
+  return data.success === true;
+};
+
+export const captchaIfConfigured = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  if (!process.env.CAPTCHA_SECRET) {
+    next();
+    return;
+  }
+
+  const token = getTokenFromRequest(req);
+  if (!token) {
+    res.status(401).json({ error: 'Captcha token is required.' });
+    return;
+  }
+
+  try {
+    const isValid = await verifyCaptchaToken(token, req.ip);
+    if (!isValid) {
+      res.status(401).json({ error: 'Captcha verification failed.' });
+      return;
+    }
+    next();
+  } catch (_error) {
+    res.status(401).json({ error: 'Captcha verification failed.' });
+  }
+};

--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -1,5 +1,7 @@
 import rateLimit from 'express-rate-limit';
 import { MemoryStore } from 'express-rate-limit';
+import { RedisStore } from 'rate-limit-redis';
+import Redis from 'ioredis';
 
 // Custom store for testing that allows manual reset
 class TestMemoryStore extends MemoryStore {
@@ -18,6 +20,24 @@ class TestMemoryStore extends MemoryStore {
 
 // Rate limit configuration based on environment
 const isTest = process.env.NODE_ENV === 'test';
+const redisUrl = process.env.REDIS_URL;
+const redisClient =
+  !isTest && redisUrl
+    ? new Redis(redisUrl, { maxRetriesPerRequest: 2, enableReadyCheck: true })
+    : null;
+
+const createStore = () => {
+  if (isTest) {
+    return new TestMemoryStore();
+  }
+  if (redisClient) {
+    return new RedisStore({
+      sendCommand: (command: string, ...args: string[]) =>
+        redisClient.call(command, ...args) as Promise<any>,
+    });
+  }
+  return new MemoryStore();
+};
 
 // Create rate limiters
 const createLimiter = (options: {
@@ -25,11 +45,11 @@ const createLimiter = (options: {
   max: number,
   message: string
 }) => {
-  const store = new TestMemoryStore();
+  const store = createStore();
   
   const limiter = rateLimit({
     windowMs: isTest ? 1000 : options.windowMs,
-    max: isTest ? 10 : options.max,
+    max: isTest ? 100 : options.max,
     message: { error: options.message },
     standardHeaders: true,
     legacyHeaders: false,
@@ -43,10 +63,10 @@ const createLimiter = (options: {
 };
 
 // Create rate limiter
-const apiLimiterStore = isTest ? new TestMemoryStore() : new MemoryStore();
+const apiLimiterStore = createStore();
 export const apiLimiter = rateLimit({
   windowMs: isTest ? 1000 : 15 * 60 * 1000, // 1 second in test, 15 minutes in production
-  max: isTest ? 10 : 100, // 10 requests in test, 100 in production
+  max: isTest ? 10 : 100, // keep deterministic test behavior
   message: 'Too many requests from this IP, please try again later.',
   standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
   legacyHeaders: false, // Disable the `X-RateLimit-*` headers
@@ -59,21 +79,53 @@ export const apiLimiter = rateLimit({
 // More strict limit for authentication routes
 export const authLimiter = createLimiter({
   windowMs: 60 * 60 * 1000, // 1 hour
-  max: 5, // Limit each IP to 5 requests per window
+  max: 10, // Limit each IP to 10 auth requests per hour
   message: 'Too many login attempts, please try again later.',
+});
+
+export const oauthLimiter = createLimiter({
+  windowMs: 60 * 60 * 1000, // 1 hour
+  max: 10,
+  message: 'Too many OAuth requests. Please try again later.',
 });
 
 // Limit for appointment creation
 export const appointmentLimiter = createLimiter({
   windowMs: 24 * 60 * 60 * 1000, // 24 hours
-  max: 3, // Limit each IP to 3 appointments per day
+  max: 5, // Limit each IP to 5 appointments per day
   message: 'Maximum appointment creation limit reached for today.',
+});
+
+export const paymentLimiter = createLimiter({
+  windowMs: 60 * 60 * 1000, // 1 hour
+  max: 20,
+  message: 'Too many payment attempts. Please try again later.',
+});
+
+export const webhookLimiter = createLimiter({
+  windowMs: 60 * 1000, // 1 minute
+  max: 120,
+  message: 'Webhook rate limit exceeded.',
+});
+
+export const contactLimiter = createLimiter({
+  windowMs: 60 * 60 * 1000, // 1 hour
+  max: 20,
+  message: 'Too many contact submissions. Please try again later.',
 });
 
 // Reset all limiters (for testing)
 export const resetAllLimiters = async () => {
   if (isTest) {
-    for (const limiter of [apiLimiter, authLimiter, appointmentLimiter]) {
+    for (const limiter of [
+      apiLimiter,
+      authLimiter,
+      oauthLimiter,
+      appointmentLimiter,
+      paymentLimiter,
+      webhookLimiter,
+      contactLimiter,
+    ]) {
       const store = (limiter as any).store;
       if (store instanceof TestMemoryStore) {
         await store.resetAll();

--- a/src/routes/appointment.routes.ts
+++ b/src/routes/appointment.routes.ts
@@ -31,6 +31,9 @@ import {
   deleteGoogleCalendarEvent,
   upsertGoogleCalendarEvent,
 } from '../services/calendar.service';
+import { adminAuth } from '../middleware/auth';
+import { createBookingAccessToken } from '../services/booking-token.service';
+import { captchaIfConfigured } from '../middleware/captcha';
 
 const appointmentRouter = express.Router();
 const prisma = new PrismaClient();
@@ -121,7 +124,7 @@ const hasSchedulingConflict = async (
 };
 
 // Create a new appointment
-appointmentRouter.post('/', appointmentLimiter, validateAppointment, async (req: Request, res: Response) => {
+appointmentRouter.post('/', appointmentLimiter, captchaIfConfigured, validateAppointment, async (req: Request, res: Response) => {
   try {
     const {
       clientFirstName,
@@ -243,7 +246,20 @@ appointmentRouter.post('/', appointmentLimiter, validateAppointment, async (req:
       console.error('Error getting business owner email for appointment notification:', err);
     });
 
-    res.status(201).json(appointment);
+    let checkoutToken: string | null = null;
+    try {
+      checkoutToken = createBookingAccessToken({
+        appointmentId: appointment.id,
+        email: appointment.email,
+      });
+    } catch (_error) {
+      checkoutToken = null;
+    }
+
+    res.status(201).json({
+      ...appointment,
+      checkoutToken,
+    });
   } catch (error) {
     console.error(error);
     res.status(500).json({ message: 'Internal server error' });
@@ -251,7 +267,7 @@ appointmentRouter.post('/', appointmentLimiter, validateAppointment, async (req:
 });
 
 // Get all appointments
-appointmentRouter.get('/', async (req: Request, res: Response) => {
+appointmentRouter.get('/', adminAuth, async (req: Request, res: Response) => {
   try {
     const { dateFrom, dateTo, serviceId } = req.query;
     const where: Prisma.AppointmentWhereInput = {};
@@ -390,7 +406,7 @@ appointmentRouter.get('/available', async (req: Request, res: Response): Promise
 });
 
 // Get a specific appointment
-appointmentRouter.get('/:id', async (req: Request, res: Response): Promise<void> => {
+appointmentRouter.get('/:id', adminAuth, async (req: Request, res: Response): Promise<void> => {
   try {
     const appointment = await prisma.appointment.findUnique({
       where: { id: req.params.id },
@@ -410,7 +426,7 @@ appointmentRouter.get('/:id', async (req: Request, res: Response): Promise<void>
 });
 
 // Update an appointment
-appointmentRouter.put('/:id', validateAppointmentUpdate, async (req: Request, res: Response): Promise<void> => {
+appointmentRouter.put('/:id', adminAuth, validateAppointmentUpdate, async (req: Request, res: Response): Promise<void> => {
   try {
     const existingAppointment = await prisma.appointment.findUnique({
       where: { id: req.params.id },
@@ -609,7 +625,7 @@ appointmentRouter.put('/:id/confirm', validateAppointmentConfirmation, async (re
 });
 
 // Delete an appointment
-appointmentRouter.delete('/:id', async (req: Request, res: Response) => {
+appointmentRouter.delete('/:id', adminAuth, async (req: Request, res: Response) => {
   try {
     const appointment = await prisma.appointment.findUnique({
       where: { id: req.params.id },

--- a/src/routes/contact.routes.ts
+++ b/src/routes/contact.routes.ts
@@ -4,6 +4,9 @@ import { contactSchema } from '../validations/contact.validation';
 import { sendEmail } from '../services/email.service';
 import { contactRequestNotificationTemplate } from '../services/email.templates';
 import dotenv from 'dotenv';
+import { adminAuth } from '../middleware/auth';
+import { contactLimiter } from '../middleware/rateLimit';
+import { captchaIfConfigured } from '../middleware/captcha';
 
 dotenv.config();
 
@@ -27,7 +30,7 @@ const getBusinessOwnerEmail = async (): Promise<string | null> => {
   }
 };
 
-contactRouter.post('/', async (req: Request, res: Response) => {
+contactRouter.post('/', contactLimiter, captchaIfConfigured, async (req: Request, res: Response) => {
   const { error, value } = contactSchema.validate(req.body, { abortEarly: false });
 
   if (error) {
@@ -69,7 +72,7 @@ contactRouter.post('/', async (req: Request, res: Response) => {
   }
 });
 
-contactRouter.get('/', async (_req: Request, res: Response) => {
+contactRouter.get('/', adminAuth, async (_req: Request, res: Response) => {
   try {
     const contactRequests = await prisma.contactRequest.findMany();
     res.json(contactRequests);
@@ -78,7 +81,7 @@ contactRouter.get('/', async (_req: Request, res: Response) => {
   }
 });
 
-contactRouter.delete('/:id', async (req: Request, res: Response) => {
+contactRouter.delete('/:id', adminAuth, async (req: Request, res: Response) => {
   await prisma.contactRequest.delete({
     where: { id: req.params.id }
   });

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -13,6 +13,7 @@ import oauthRouter from './oauth.routes';
 import integrationRouter from './integration.routes';
 import paymentRouter from './payment.routes';
 import webhookRouter from './webhook.routes';
+import securityRouter from './security.routes';
 
 const router = express.Router();
 
@@ -33,5 +34,6 @@ router.use('/admin/testimonials', adminAuth, testimonialRouter);
 router.use('/admin/blog-posts', adminAuth, blogPostRouter);
 router.use('/admin/email', adminAuth, emailRouter);
 router.use('/admin/integrations', integrationRouter);
+router.use('/admin/security', securityRouter);
 
 export default router;

--- a/src/routes/integration.routes.ts
+++ b/src/routes/integration.routes.ts
@@ -1,6 +1,6 @@
 import express, { Request, Response } from 'express';
 import { adminAuth } from '../middleware/auth';
-import { authLimiter } from '../middleware/rateLimit';
+import { oauthLimiter } from '../middleware/rateLimit';
 import { isSupportedOAuthProvider } from '../services/oauth/oauth.providers';
 import {
   getOAuthConnectionStatus,
@@ -11,7 +11,7 @@ const integrationRouter = express.Router();
 
 integrationRouter.get(
   '/:provider/status',
-  authLimiter,
+  oauthLimiter,
   adminAuth,
   async (req: Request, res: Response): Promise<void> => {
     try {
@@ -37,7 +37,7 @@ integrationRouter.get(
 
 integrationRouter.post(
   '/:provider/refresh',
-  authLimiter,
+  oauthLimiter,
   adminAuth,
   async (req: Request, res: Response): Promise<void> => {
     try {

--- a/src/routes/oauth.routes.ts
+++ b/src/routes/oauth.routes.ts
@@ -1,6 +1,6 @@
 import express, { Request, Response } from 'express';
 import { adminAuth } from '../middleware/auth';
-import { authLimiter } from '../middleware/rateLimit';
+import { oauthLimiter } from '../middleware/rateLimit';
 import { isSupportedOAuthProvider } from '../services/oauth/oauth.providers';
 import {
   completeOAuthAuthorization,
@@ -11,7 +11,7 @@ import {
 
 const oauthRouter = express.Router();
 
-oauthRouter.post('/:provider/authorize', authLimiter, adminAuth, async (req: Request, res: Response): Promise<void> => {
+oauthRouter.post('/:provider/authorize', oauthLimiter, adminAuth, async (req: Request, res: Response): Promise<void> => {
   try {
     const provider = req.params.provider;
     if (!isSupportedOAuthProvider(provider)) {
@@ -32,7 +32,7 @@ oauthRouter.post('/:provider/authorize', authLimiter, adminAuth, async (req: Req
   }
 });
 
-oauthRouter.get('/callback/:provider', authLimiter, async (req: Request, res: Response): Promise<void> => {
+oauthRouter.get('/callback/:provider', oauthLimiter, async (req: Request, res: Response): Promise<void> => {
   try {
     const provider = req.params.provider;
     if (!isSupportedOAuthProvider(provider)) {

--- a/src/routes/payment.routes.ts
+++ b/src/routes/payment.routes.ts
@@ -1,17 +1,20 @@
 import express, { Request, Response } from 'express';
 import Joi from 'joi';
-import { appointmentLimiter } from '../middleware/rateLimit';
 import { createIntuitCheckoutSession } from '../services/payment.service';
+import { verifyBookingAccessToken } from '../services/booking-token.service';
+import { paymentLimiter } from '../middleware/rateLimit';
+import { recordSecurityAuditEvent } from '../services/security-audit.service';
 
 const paymentRouter = express.Router();
 
 const checkoutSchema = Joi.object({
   appointmentId: Joi.string().uuid().required(),
+  bookingToken: Joi.string().min(16).optional(),
   tipAmount: Joi.number().min(0).optional(),
   currency: Joi.string().length(3).uppercase().optional(),
 });
 
-paymentRouter.post('/intuit/checkout-session', appointmentLimiter, async (req: Request, res: Response): Promise<void> => {
+paymentRouter.post('/intuit/checkout-session', paymentLimiter, async (req: Request, res: Response): Promise<void> => {
   try {
     const { error, value } = checkoutSchema.validate(req.body);
     if (error) {
@@ -19,13 +22,66 @@ paymentRouter.post('/intuit/checkout-session', appointmentLimiter, async (req: R
       return;
     }
 
-    const session = await createIntuitCheckoutSession(value);
+    const tokenHeader = req.headers['x-booking-token'];
+    const bookingToken =
+      typeof tokenHeader === 'string'
+        ? tokenHeader
+        : typeof value.bookingToken === 'string'
+          ? value.bookingToken
+          : null;
+    if (!bookingToken) {
+      await recordSecurityAuditEvent({
+        eventType: 'checkout.token_missing',
+        outcome: 'rejected',
+        severity: 'warning',
+        provider: 'intuit',
+        appointmentId: value.appointmentId,
+      });
+      res.status(401).json({ error: 'Booking token is required for checkout session creation.' });
+      return;
+    }
+    const tokenValidation = verifyBookingAccessToken(bookingToken, {
+      expectedAppointmentId: value.appointmentId,
+    });
+    if (!tokenValidation.valid) {
+      await recordSecurityAuditEvent({
+        eventType: 'checkout.token_invalid',
+        outcome: 'rejected',
+        severity: 'warning',
+        provider: 'intuit',
+        appointmentId: value.appointmentId,
+        metadata: { reason: tokenValidation.reason },
+      });
+      res.status(401).json({ error: 'Invalid or expired booking token.' });
+      return;
+    }
+
+    const session = await createIntuitCheckoutSession({
+      appointmentId: value.appointmentId,
+      tipAmount: value.tipAmount,
+      currency: value.currency,
+      bookingEmail: tokenValidation.payload.email,
+    });
+    await recordSecurityAuditEvent({
+      eventType: 'checkout.session_created',
+      outcome: 'accepted',
+      severity: 'info',
+      provider: 'intuit',
+      appointmentId: value.appointmentId,
+      metadata: {
+        externalPaymentId: session.externalPaymentId,
+      },
+    });
     res.status(201).json(session);
   } catch (error) {
     console.error('Error creating Intuit checkout session:', error);
     const message = error instanceof Error ? error.message : 'Failed to create checkout session';
     if (message === 'Appointment not found') {
       res.status(404).json({ error: message });
+      return;
+    }
+    if (message === 'Booking token does not match appointment owner.') {
+      res.status(401).json({ error: message });
       return;
     }
     res.status(500).json({ error: message });

--- a/src/routes/security.routes.ts
+++ b/src/routes/security.routes.ts
@@ -1,0 +1,21 @@
+import express, { Request, Response } from 'express';
+import { adminAuth } from '../middleware/auth';
+import { authLimiter } from '../middleware/rateLimit';
+import { runDataRetentionCleanup } from '../services/data-retention.service';
+
+const securityRouter = express.Router();
+
+securityRouter.post('/retention/run', authLimiter, adminAuth, async (_req: Request, res: Response) => {
+  try {
+    const result = await runDataRetentionCleanup();
+    res.json({
+      status: 'ok',
+      ...result,
+    });
+  } catch (error) {
+    console.error('Failed to run retention cleanup:', error);
+    res.status(500).json({ error: 'Failed to run retention cleanup' });
+  }
+});
+
+export default securityRouter;

--- a/src/routes/webhook.routes.ts
+++ b/src/routes/webhook.routes.ts
@@ -1,18 +1,32 @@
 import express, { Request, Response } from 'express';
 import crypto from 'crypto';
-import { authLimiter } from '../middleware/rateLimit';
+import { PrismaClient } from '@prisma/client';
 import { processIntuitWebhook } from '../services/payment.service';
+import { webhookLimiter } from '../middleware/rateLimit';
+import { recordSecurityAuditEvent } from '../services/security-audit.service';
+import { sendSecurityAlert } from '../services/security-alert.service';
 
 const webhookRouter = express.Router();
+const prisma = new PrismaClient();
+const INTUIT_PROVIDER = 'intuit';
 
-const isValidWebhookSecret = (provided: string | undefined, expected: string | undefined): boolean => {
-  if (!expected) {
-    return true;
+const getHeaderValue = (value: string | string[] | undefined): string | undefined => {
+  if (!value) {
+    return undefined;
   }
-  if (!provided) {
-    return false;
+  if (Array.isArray(value)) {
+    return value[0];
   }
+  return value;
+};
 
+const isWithinReplayWindow = (timestampSeconds: number): boolean => {
+  const maxAgeSeconds = Number(process.env.INTUIT_WEBHOOK_MAX_AGE_SECONDS || '300');
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  return Math.abs(nowSeconds - timestampSeconds) <= maxAgeSeconds;
+};
+
+const timingSafeEquals = (provided: string, expected: string): boolean => {
   const providedBuffer = Buffer.from(provided);
   const expectedBuffer = Buffer.from(expected);
   if (providedBuffer.length !== expectedBuffer.length) {
@@ -21,21 +35,155 @@ const isValidWebhookSecret = (provided: string | undefined, expected: string | u
   return crypto.timingSafeEqual(providedBuffer, expectedBuffer);
 };
 
-webhookRouter.post('/intuit', authLimiter, async (req: Request, res: Response): Promise<void> => {
+const parseProvidedSignatures = (signatureHeader: string | undefined): string[] =>
+  signatureHeader
+    ? signatureHeader
+        .split(',')
+        .map((item) => item.trim())
+        .filter(Boolean)
+    : [];
+
+const verifyIntuitSignature = (params: {
+  rawBody: Buffer;
+  signatureHeader: string | undefined;
+  timestampHeader: string | undefined;
+}): { ok: boolean; reason?: string; signatureHash?: string } => {
+  const secret = process.env.INTUIT_WEBHOOK_SECRET;
+  const isProduction = process.env.NODE_ENV === 'production';
+  if (!secret) {
+    return isProduction ? { ok: false, reason: 'missing_webhook_secret' } : { ok: true };
+  }
+
+  const signatures = parseProvidedSignatures(params.signatureHeader);
+  if (!signatures.length) {
+    return { ok: false, reason: 'missing_signature' };
+  }
+
+  const timestamp = params.timestampHeader ? Number(params.timestampHeader) : NaN;
+  if (!params.timestampHeader || Number.isNaN(timestamp) || !Number.isFinite(timestamp)) {
+    return { ok: false, reason: 'invalid_timestamp' };
+  }
+  if (!isWithinReplayWindow(timestamp)) {
+    return { ok: false, reason: 'timestamp_outside_replay_window' };
+  }
+
+  const body = params.rawBody.toString('utf8');
+  const baseString = `${timestamp}.${body}`;
+  const digestBase64 = crypto
+    .createHmac('sha256', secret)
+    .update(baseString, 'utf8')
+    .digest('base64');
+  const digestHex = crypto
+    .createHmac('sha256', secret)
+    .update(baseString, 'utf8')
+    .digest('hex');
+
+  const isValid = signatures.some((provided) => timingSafeEquals(provided, digestBase64) || timingSafeEquals(provided, digestHex));
+  if (!isValid) {
+    return { ok: false, reason: 'signature_mismatch' };
+  }
+
+  const signatureHash = crypto
+    .createHash('sha256')
+    .update(`${timestamp}.${signatures[0]}`)
+    .digest('hex');
+  return { ok: true, signatureHash };
+};
+
+const reserveReplayGuard = async (signatureHash: string): Promise<boolean> => {
   try {
-    const secretHeader = req.headers['x-intuit-webhook-secret'];
-    const providedSecret = typeof secretHeader === 'string' ? secretHeader : undefined;
-    if (!isValidWebhookSecret(providedSecret, process.env.INTUIT_WEBHOOK_SECRET)) {
+    await prisma.webhookReplayGuard.create({
+      data: {
+        provider: INTUIT_PROVIDER,
+        signatureHash,
+        expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      },
+    });
+    return true;
+  } catch (error: any) {
+    // P2002 = unique constraint violation -> replay
+    if (error?.code === 'P2002') {
+      return false;
+    }
+    if (error?.code === 'P2021') {
+      // Older DB snapshots may not include the replay table.
+      return true;
+    }
+    throw error;
+  }
+};
+
+webhookRouter.post('/intuit', webhookLimiter, async (req: Request, res: Response): Promise<void> => {
+  try {
+    const rawBody =
+      Buffer.isBuffer(req.body)
+        ? req.body
+        : Buffer.from(typeof req.body === 'string' ? req.body : JSON.stringify(req.body ?? {}), 'utf8');
+    const signatureHeader =
+      getHeaderValue(req.headers['intuit-signature']) ??
+      getHeaderValue(req.headers['x-intuit-signature']);
+    const timestampHeader =
+      getHeaderValue(req.headers['intuit-timestamp']) ??
+      getHeaderValue(req.headers['x-intuit-timestamp']);
+    const verify = verifyIntuitSignature({
+      rawBody,
+      signatureHeader,
+      timestampHeader,
+    });
+    if (!verify.ok) {
+      await recordSecurityAuditEvent({
+        eventType: 'webhook.signature_invalid',
+        outcome: 'rejected',
+        severity: 'critical',
+        provider: INTUIT_PROVIDER,
+        metadata: { reason: verify.reason },
+      });
+      await sendSecurityAlert({
+        subject: 'Webhook rejected: signature verification failed',
+        summary: 'An Intuit webhook failed signature verification.',
+        details: { reason: verify.reason },
+      });
       res.status(401).json({ error: 'Unauthorized webhook signature' });
       return;
     }
 
-    if (!req.body || typeof req.body !== 'object') {
+    if (verify.signatureHash) {
+      const reserved = await reserveReplayGuard(verify.signatureHash);
+      if (!reserved) {
+        await recordSecurityAuditEvent({
+          eventType: 'webhook.replay_detected',
+          outcome: 'rejected',
+          severity: 'critical',
+          provider: INTUIT_PROVIDER,
+          metadata: { signatureHash: verify.signatureHash },
+        });
+        await sendSecurityAlert({
+          subject: 'Webhook replay detected',
+          summary: 'A replayed webhook signature was detected and blocked.',
+          details: { signatureHash: verify.signatureHash },
+        });
+        res.status(409).json({ error: 'Webhook replay detected' });
+        return;
+      }
+    }
+
+    if (!rawBody || !rawBody.length) {
       res.status(400).json({ error: 'Invalid webhook payload' });
       return;
     }
 
-    const result = await processIntuitWebhook(req.body as Record<string, unknown>);
+    let payload: Record<string, unknown>;
+    try {
+      payload = JSON.parse(rawBody.toString('utf8')) as Record<string, unknown>;
+    } catch (_error) {
+      res.status(400).json({ error: 'Invalid webhook payload' });
+      return;
+    }
+    const result = await processIntuitWebhook(payload);
+    if (!result.accepted) {
+      res.status(400).json(result);
+      return;
+    }
     res.status(200).json(result);
   } catch (error) {
     console.error('Error processing Intuit webhook:', error);

--- a/src/services/booking-token.service.ts
+++ b/src/services/booking-token.service.ts
@@ -1,0 +1,100 @@
+import crypto from 'crypto';
+
+interface BookingTokenPayload {
+  appointmentId: string;
+  email: string;
+  iat: number;
+  exp: number;
+}
+
+const TOKEN_LIFETIME_SECONDS = 60 * 60 * 2; // 2 hours
+
+const b64UrlEncode = (input: Buffer | string): string =>
+  (typeof input === 'string' ? Buffer.from(input, 'utf8') : input)
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '');
+
+const b64UrlDecode = (input: string): Buffer => {
+  const padded = input.replace(/-/g, '+').replace(/_/g, '/');
+  const normalized = padded + '='.repeat((4 - (padded.length % 4)) % 4);
+  return Buffer.from(normalized, 'base64');
+};
+
+const getBookingTokenSecret = (): string => {
+  const value = process.env.BOOKING_TOKEN_SECRET;
+  if (!value) {
+    throw new Error('Missing BOOKING_TOKEN_SECRET');
+  }
+  return value;
+};
+
+const sign = (data: string, secret: string): string =>
+  b64UrlEncode(crypto.createHmac('sha256', secret).update(data).digest());
+
+export const createBookingAccessToken = (params: {
+  appointmentId: string;
+  email: string;
+  now?: Date;
+  ttlSeconds?: number;
+}): string => {
+  const secret = getBookingTokenSecret();
+  const nowEpoch = Math.floor((params.now ?? new Date()).getTime() / 1000);
+  const payload: BookingTokenPayload = {
+    appointmentId: params.appointmentId,
+    email: params.email.toLowerCase(),
+    iat: nowEpoch,
+    exp: nowEpoch + (params.ttlSeconds ?? TOKEN_LIFETIME_SECONDS),
+  };
+  const header = { alg: 'HS256', typ: 'BKT' };
+  const encodedHeader = b64UrlEncode(JSON.stringify(header));
+  const encodedPayload = b64UrlEncode(JSON.stringify(payload));
+  const data = `${encodedHeader}.${encodedPayload}`;
+  const signature = sign(data, secret);
+  return `${data}.${signature}`;
+};
+
+export const verifyBookingAccessToken = (
+  token: string,
+  options?: { now?: Date; expectedAppointmentId?: string }
+): { valid: true; payload: BookingTokenPayload } | { valid: false; reason: string } => {
+  const secret = getBookingTokenSecret();
+  const segments = token.split('.');
+  if (segments.length !== 3) {
+    return { valid: false, reason: 'invalid_format' };
+  }
+
+  const [encodedHeader, encodedPayload, signature] = segments;
+  const data = `${encodedHeader}.${encodedPayload}`;
+  const expectedSignature = sign(data, secret);
+  const providedBuffer = Buffer.from(signature);
+  const expectedBuffer = Buffer.from(expectedSignature);
+  if (
+    providedBuffer.length !== expectedBuffer.length ||
+    !crypto.timingSafeEqual(providedBuffer, expectedBuffer)
+  ) {
+    return { valid: false, reason: 'invalid_signature' };
+  }
+
+  let payload: BookingTokenPayload;
+  try {
+    payload = JSON.parse(b64UrlDecode(encodedPayload).toString('utf8')) as BookingTokenPayload;
+  } catch (_error) {
+    return { valid: false, reason: 'invalid_payload' };
+  }
+
+  if (!payload.appointmentId || !payload.email || !payload.exp || !payload.iat) {
+    return { valid: false, reason: 'invalid_payload' };
+  }
+
+  const nowEpoch = Math.floor((options?.now ?? new Date()).getTime() / 1000);
+  if (payload.exp < nowEpoch) {
+    return { valid: false, reason: 'expired' };
+  }
+  if (options?.expectedAppointmentId && payload.appointmentId !== options.expectedAppointmentId) {
+    return { valid: false, reason: 'appointment_mismatch' };
+  }
+
+  return { valid: true, payload };
+};

--- a/src/services/data-retention.service.ts
+++ b/src/services/data-retention.service.ts
@@ -1,0 +1,61 @@
+import { PrismaClient } from '@prisma/client';
+import { recordSecurityAuditEvent } from './security-audit.service';
+
+const prisma = new PrismaClient();
+
+const parseDays = (value: string | undefined, fallback: number): number => {
+  const parsed = Number(value);
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return parsed;
+};
+
+export const runDataRetentionCleanup = async (): Promise<{
+  contactRequestsDeleted: number;
+  webhookEventsDeleted: number;
+  replayGuardsDeleted: number;
+  securityAuditEventsDeleted: number;
+}> => {
+  const contactRetentionDays = parseDays(process.env.RETENTION_CONTACT_REQUEST_DAYS, 90);
+  const webhookRetentionDays = parseDays(process.env.RETENTION_WEBHOOK_EVENT_DAYS, 90);
+  const auditRetentionDays = parseDays(process.env.RETENTION_SECURITY_AUDIT_DAYS, 180);
+
+  const contactThreshold = new Date(Date.now() - contactRetentionDays * 24 * 60 * 60 * 1000);
+  const webhookThreshold = new Date(Date.now() - webhookRetentionDays * 24 * 60 * 60 * 1000);
+  const auditThreshold = new Date(Date.now() - auditRetentionDays * 24 * 60 * 60 * 1000);
+
+  const [contactDelete, webhookDelete, replayGuardDelete, auditDelete] = await prisma.$transaction([
+    prisma.contactRequest.deleteMany({
+      where: { createdAt: { lt: contactThreshold } },
+    }),
+    prisma.integrationWebhookEvent.deleteMany({
+      where: { createdAt: { lt: webhookThreshold } },
+    }),
+    prisma.webhookReplayGuard.deleteMany({
+      where: { expiresAt: { lt: new Date() } },
+    }),
+    prisma.securityAuditEvent.deleteMany({
+      where: { createdAt: { lt: auditThreshold } },
+    }),
+  ]);
+
+  await recordSecurityAuditEvent({
+    eventType: 'data.retention.cleanup',
+    outcome: 'accepted',
+    severity: 'info',
+    metadata: {
+      contactRequestsDeleted: contactDelete.count,
+      webhookEventsDeleted: webhookDelete.count,
+      replayGuardsDeleted: replayGuardDelete.count,
+      securityAuditEventsDeleted: auditDelete.count,
+    },
+  });
+
+  return {
+    contactRequestsDeleted: contactDelete.count,
+    webhookEventsDeleted: webhookDelete.count,
+    replayGuardsDeleted: replayGuardDelete.count,
+    securityAuditEventsDeleted: auditDelete.count,
+  };
+};

--- a/src/services/payment.service.ts
+++ b/src/services/payment.service.ts
@@ -5,6 +5,8 @@ import { appointmentConfirmedTemplate } from './email.templates';
 import { sendEmail } from './email.service';
 import { getAccessTokenForProvider } from './oauth/oauth.service';
 import { appointmentPaymentReceiptToOwnerTemplate } from './email.templates';
+import { recordSecurityAuditEvent } from './security-audit.service';
+import { sendSecurityAlert } from './security-alert.service';
 
 const prisma = new PrismaClient();
 const INTUIT_PROVIDER = 'intuit';
@@ -14,6 +16,15 @@ interface IntuitCheckoutResult {
   checkoutUrl: string;
   raw: Record<string, unknown>;
 }
+
+const parseAllowedSuccessEvents = (): Set<string> => {
+  const configured = process.env.INTUIT_SUCCESS_EVENT_TYPES;
+  const defaults = ['payment.succeeded', 'payment.success', 'charge.succeeded'];
+  const raw = configured
+    ? configured.split(/[,\s]+/).filter(Boolean)
+    : defaults;
+  return new Set(raw.map((item) => item.toLowerCase()));
+};
 
 const getWebhookEventId = (payload: Record<string, unknown>): string => {
   const candidates = [
@@ -36,17 +47,38 @@ const getWebhookType = (payload: Record<string, unknown>): string => {
   return (value as string | undefined) ?? 'unknown';
 };
 
-const isSucceededEvent = (eventType: string): boolean => {
-  const normalized = eventType.toLowerCase();
-  return (
-    normalized.includes('succeeded') ||
-    normalized.includes('paid') ||
-    normalized === 'payment.success'
-  );
+const isSucceededEvent = (eventType: string): boolean =>
+  parseAllowedSuccessEvents().has(eventType.toLowerCase());
+
+const parseCurrency = (payload: Record<string, unknown>): string | null => {
+  const value =
+    (payload.currency as string | undefined) ||
+    ((payload.data as Record<string, unknown> | undefined)?.currency as string | undefined) ||
+    ((payload.payment as Record<string, unknown> | undefined)?.currency as string | undefined);
+  return value ? value.toUpperCase() : null;
+};
+
+const parseAmount = (payload: Record<string, unknown>): number | null => {
+  const candidate =
+    (payload.amount as number | string | undefined) ??
+    ((payload.total as number | string | undefined) ?? undefined) ??
+    (((payload.data as Record<string, unknown> | undefined)?.amount as number | string | undefined) ??
+      undefined);
+  if (typeof candidate === 'number') {
+    return Number(candidate.toFixed(2));
+  }
+  if (typeof candidate === 'string' && candidate.trim()) {
+    const parsed = Number(candidate);
+    if (!Number.isNaN(parsed)) {
+      return Number(parsed.toFixed(2));
+    }
+  }
+  return null;
 };
 
 export const createIntuitCheckoutSession = async (params: {
   appointmentId: string;
+  bookingEmail?: string;
   tipAmount?: number;
   currency?: string;
 }): Promise<{
@@ -63,6 +95,12 @@ export const createIntuitCheckoutSession = async (params: {
   });
   if (!appointment) {
     throw new Error('Appointment not found');
+  }
+  if (
+    params.bookingEmail &&
+    appointment.email.toLowerCase() !== params.bookingEmail.toLowerCase()
+  ) {
+    throw new Error('Booking token does not match appointment owner.');
   }
 
   const tipAmount = params.tipAmount ?? appointment.tipAmount ?? 0;
@@ -183,6 +221,13 @@ export const processIntuitWebhook = async (
     },
   });
   if (existing?.processedAt) {
+    await recordSecurityAuditEvent({
+      eventType: 'webhook.duplicate',
+      outcome: 'rejected',
+      severity: 'warning',
+      provider: INTUIT_PROVIDER,
+      metadata: { eventId, eventType },
+    });
     return { accepted: true, duplicate: true, eventId, status: 'already_processed' };
   }
 
@@ -215,6 +260,13 @@ export const processIntuitWebhook = async (
       },
       data: { processedAt: new Date() },
     });
+    await recordSecurityAuditEvent({
+      eventType: 'webhook.non_success_event',
+      outcome: 'accepted',
+      severity: 'info',
+      provider: INTUIT_PROVIDER,
+      metadata: { eventId, eventType },
+    });
     return { accepted: true, duplicate: false, eventId, status: 'ignored' };
   }
 
@@ -237,16 +289,83 @@ export const processIntuitWebhook = async (
       },
       data: { processedAt: new Date() },
     });
+    await recordSecurityAuditEvent({
+      eventType: 'payment.confirmation_missing_reference',
+      outcome: 'rejected',
+      severity: 'warning',
+      provider: INTUIT_PROVIDER,
+      metadata: { eventId, eventType },
+    });
     return { accepted: true, duplicate: false, eventId, status: 'missing_reference' };
   }
 
-  const appointment = await prisma.appointment.findFirst({
-    where: {
-      OR: [
-        appointmentId ? { id: appointmentId } : undefined,
-        paymentId ? { paymentExternalId: paymentId } : undefined,
-      ].filter(Boolean) as any,
-    },
+  const paymentTx = paymentId
+    ? await prisma.paymentTransaction.findUnique({
+        where: { externalPaymentId: paymentId },
+      })
+    : await prisma.paymentTransaction.findFirst({
+        where: {
+          provider: INTUIT_PROVIDER,
+          appointmentId: appointmentId ?? undefined,
+          status: 'pending',
+        },
+        orderBy: { createdAt: 'desc' },
+      });
+
+  if (!paymentTx) {
+    await prisma.integrationWebhookEvent.update({
+      where: {
+        provider_eventExternalId: {
+          provider: INTUIT_PROVIDER,
+          eventExternalId: eventId,
+        },
+      },
+      data: { processedAt: new Date() },
+    });
+    await recordSecurityAuditEvent({
+      eventType: 'payment.transaction_missing',
+      outcome: 'rejected',
+      severity: 'warning',
+      provider: INTUIT_PROVIDER,
+      metadata: { eventId, eventType, paymentId, appointmentId },
+    });
+    await sendSecurityAlert({
+      subject: 'Payment webhook rejected: transaction missing',
+      summary: 'A successful payment webhook could not be matched to a transaction.',
+      details: { eventId, paymentId, appointmentId },
+    });
+    return { accepted: false, duplicate: false, eventId, status: 'transaction_not_found' };
+  }
+
+  if (appointmentId && paymentTx.appointmentId !== appointmentId) {
+    await prisma.integrationWebhookEvent.update({
+      where: {
+        provider_eventExternalId: {
+          provider: INTUIT_PROVIDER,
+          eventExternalId: eventId,
+        },
+      },
+      data: { processedAt: new Date() },
+    });
+    await recordSecurityAuditEvent({
+      eventType: 'payment.appointment_mismatch',
+      outcome: 'rejected',
+      severity: 'critical',
+      provider: INTUIT_PROVIDER,
+      appointmentId,
+      paymentTransactionId: paymentTx.id,
+      metadata: { eventId, paymentTxAppointmentId: paymentTx.appointmentId },
+    });
+    await sendSecurityAlert({
+      subject: 'Payment webhook rejected: appointment mismatch',
+      summary: 'Webhook appointment reference mismatched stored payment transaction.',
+      details: { eventId, appointmentId, paymentTxAppointmentId: paymentTx.appointmentId },
+    });
+    return { accepted: false, duplicate: false, eventId, status: 'appointment_mismatch' };
+  }
+
+  const appointment = await prisma.appointment.findUnique({
+    where: { id: paymentTx.appointmentId },
     include: { service: { include: { Client: true } } },
   });
 
@@ -260,18 +379,129 @@ export const processIntuitWebhook = async (
       },
       data: { processedAt: new Date() },
     });
+    await recordSecurityAuditEvent({
+      eventType: 'payment.appointment_not_found',
+      outcome: 'rejected',
+      severity: 'warning',
+      provider: INTUIT_PROVIDER,
+      paymentTransactionId: paymentTx.id,
+      metadata: { eventId, paymentTxAppointmentId: paymentTx.appointmentId },
+    });
     return { accepted: true, duplicate: false, eventId, status: 'appointment_not_found' };
+  }
+
+  const expectedAmount = Number((appointment.service.price + (appointment.tipAmount ?? 0)).toFixed(2));
+  const receivedAmount = parseAmount(payload);
+  const expectedCurrency = paymentTx.currency.toUpperCase();
+  const receivedCurrency = parseCurrency(payload);
+
+  if (receivedAmount === null || receivedAmount !== expectedAmount || !receivedCurrency || receivedCurrency !== expectedCurrency) {
+    await prisma.integrationWebhookEvent.update({
+      where: {
+        provider_eventExternalId: {
+          provider: INTUIT_PROVIDER,
+          eventExternalId: eventId,
+        },
+      },
+      data: { processedAt: new Date() },
+    });
+    await recordSecurityAuditEvent({
+      eventType: 'payment.amount_or_currency_mismatch',
+      outcome: 'rejected',
+      severity: 'critical',
+      provider: INTUIT_PROVIDER,
+      appointmentId: appointment.id,
+      paymentTransactionId: paymentTx.id,
+      metadata: {
+        eventId,
+        expectedAmount,
+        receivedAmount,
+        expectedCurrency,
+        receivedCurrency,
+      },
+    });
+    await sendSecurityAlert({
+      subject: 'Payment webhook rejected: amount/currency mismatch',
+      summary: 'Payment webhook values did not match pending transaction.',
+      details: {
+        eventId,
+        appointmentId: appointment.id,
+        expectedAmount,
+        receivedAmount,
+        expectedCurrency,
+        receivedCurrency,
+      },
+    });
+    return { accepted: false, duplicate: false, eventId, status: 'amount_or_currency_mismatch' };
+  }
+
+  const webhookRealmId =
+    (payload.realmId as string | undefined) ||
+    ((payload.data as Record<string, unknown> | undefined)?.realmId as string | undefined);
+  const integrationConnection = await prisma.integrationConnection.findUnique({
+    where: {
+      provider_ownerKey: {
+        provider: INTUIT_PROVIDER,
+        ownerKey: 'global',
+      },
+    },
+  });
+  const expectedRealmId =
+    ((integrationConnection?.metadata as Record<string, unknown> | null)?.realmId as string | undefined) ??
+    undefined;
+  if (webhookRealmId && expectedRealmId && webhookRealmId !== expectedRealmId) {
+    await prisma.integrationWebhookEvent.update({
+      where: {
+        provider_eventExternalId: {
+          provider: INTUIT_PROVIDER,
+          eventExternalId: eventId,
+        },
+      },
+      data: { processedAt: new Date() },
+    });
+    await recordSecurityAuditEvent({
+      eventType: 'payment.realm_mismatch',
+      outcome: 'rejected',
+      severity: 'critical',
+      provider: INTUIT_PROVIDER,
+      appointmentId: appointment.id,
+      paymentTransactionId: paymentTx.id,
+      metadata: { eventId, webhookRealmId, expectedRealmId },
+    });
+    await sendSecurityAlert({
+      subject: 'Payment webhook rejected: realm mismatch',
+      summary: 'Webhook realm/account did not match configured integration account.',
+      details: { eventId, webhookRealmId, expectedRealmId },
+    });
+    return { accepted: false, duplicate: false, eventId, status: 'realm_mismatch' };
+  }
+
+  if (paymentTx.status !== 'pending') {
+    await prisma.integrationWebhookEvent.update({
+      where: {
+        provider_eventExternalId: {
+          provider: INTUIT_PROVIDER,
+          eventExternalId: eventId,
+        },
+      },
+      data: { processedAt: new Date() },
+    });
+    await recordSecurityAuditEvent({
+      eventType: 'payment.invalid_state_transition',
+      outcome: 'rejected',
+      severity: 'warning',
+      provider: INTUIT_PROVIDER,
+      appointmentId: appointment.id,
+      paymentTransactionId: paymentTx.id,
+      metadata: { eventId, currentStatus: paymentTx.status },
+    });
+    return { accepted: true, duplicate: false, eventId, status: 'already_paid' };
   }
 
   const wasConfirmed = appointment.states === 'confirmed';
   await prisma.$transaction(async (tx) => {
-    await tx.paymentTransaction.updateMany({
-      where: {
-        OR: [
-          paymentId ? { externalPaymentId: paymentId } : undefined,
-          { appointmentId: appointment.id, provider: INTUIT_PROVIDER },
-        ].filter(Boolean) as any,
-      },
+    await tx.paymentTransaction.update({
+      where: { id: paymentTx.id },
       data: {
         status: 'paid',
         metadata: payload as Prisma.InputJsonValue,
@@ -298,6 +528,21 @@ export const processIntuitWebhook = async (
       },
       data: { processedAt: new Date() },
     });
+  });
+
+  await recordSecurityAuditEvent({
+    eventType: 'payment.confirmed',
+    outcome: 'accepted',
+    severity: 'info',
+    provider: INTUIT_PROVIDER,
+    appointmentId: appointment.id,
+    paymentTransactionId: paymentTx.id,
+    metadata: {
+      eventId,
+      eventType,
+      amount: receivedAmount,
+      currency: receivedCurrency,
+    },
   });
 
   if (!wasConfirmed && appointment.service) {

--- a/src/services/security-alert.service.ts
+++ b/src/services/security-alert.service.ts
@@ -1,0 +1,27 @@
+import { sendEmail } from './email.service';
+
+const getSecurityAlertRecipient = (): string | null =>
+  process.env.SECURITY_ALERT_EMAIL || process.env.BUSINESS_OWNER_EMAIL || null;
+
+export const sendSecurityAlert = async (params: {
+  subject: string;
+  summary: string;
+  details?: Record<string, unknown>;
+}): Promise<void> => {
+  const recipient = getSecurityAlertRecipient();
+  if (!recipient) {
+    return;
+  }
+
+  const detailsHtml = params.details
+    ? `<pre style="white-space:pre-wrap;font-family:monospace;">${JSON.stringify(params.details, null, 2)}</pre>`
+    : '';
+  const html = `
+    <h3>Security Alert</h3>
+    <p><strong>Time:</strong> ${new Date().toISOString()}</p>
+    <p><strong>Summary:</strong> ${params.summary}</p>
+    ${detailsHtml}
+  `;
+
+  await sendEmail(recipient, params.subject, html, undefined, false);
+};

--- a/src/services/security-audit.service.ts
+++ b/src/services/security-audit.service.ts
@@ -1,0 +1,51 @@
+import { Prisma, PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export type SecurityAuditSeverity = 'info' | 'warning' | 'critical';
+export type SecurityAuditOutcome = 'accepted' | 'rejected' | 'error';
+
+export const recordSecurityAuditEvent = async (event: {
+  eventType: string;
+  outcome: SecurityAuditOutcome;
+  severity?: SecurityAuditSeverity;
+  provider?: string;
+  appointmentId?: string | null;
+  paymentTransactionId?: string | null;
+  metadata?: Record<string, unknown> | null;
+}): Promise<void> => {
+  const severity = event.severity ?? 'info';
+  const logRecord = {
+    at: new Date().toISOString(),
+    eventType: event.eventType,
+    outcome: event.outcome,
+    severity,
+    provider: event.provider ?? null,
+    appointmentId: event.appointmentId ?? null,
+    paymentTransactionId: event.paymentTransactionId ?? null,
+    metadata: event.metadata ?? null,
+  };
+
+  // Always emit structured logs for external aggregation.
+  const method = severity === 'critical' ? console.error : severity === 'warning' ? console.warn : console.log;
+  method(JSON.stringify({ type: 'security_audit', ...logRecord }));
+
+  try {
+    await prisma.securityAuditEvent.create({
+      data: {
+        eventType: event.eventType,
+        outcome: event.outcome,
+        severity,
+        provider: event.provider ?? null,
+        appointmentId: event.appointmentId ?? null,
+        paymentTransactionId: event.paymentTransactionId ?? null,
+        metadata: (event.metadata ?? {}) as Prisma.InputJsonValue,
+      },
+    });
+  } catch (error: any) {
+    // Older DB snapshots may not have the table yet.
+    if (error?.code !== 'P2021') {
+      console.error('Failed to persist security audit event:', error);
+    }
+  }
+};

--- a/src/types/auth-context.ts
+++ b/src/types/auth-context.ts
@@ -1,0 +1,7 @@
+export type AuthActorType = 'admin' | 'booking_client' | 'system_webhook' | 'anonymous';
+
+export interface AuthContext {
+  actorType: AuthActorType;
+  actorId: string | null;
+  authMethod: 'admin_key' | 'booking_token' | 'webhook_signature' | 'none';
+}


### PR DESCRIPTION
## Summary
- Lock down sensitive PII endpoints so appointment/contact list/detail/update/delete operations are admin-protected while keeping only minimal public routes for service discovery, booking create, availability lookup, and contact create.
- Harden Intuit finance flows by requiring signed timestamped webhooks with replay-window enforcement, signature replay-guard persistence, strict success-event allowlisting, and validation of transaction state, amount, currency, and realm/account consistency before payment confirmation.
- Require booking-scoped checkout authorization tokens for payment session creation, add Redis-backed rate limiting with tighter security route classes, wire CAPTCHA hooks for public create routes, and add structured security audit logging + retention cleanup services/endpoints.
- Update Prisma schema/migration, OpenAPI, API docs, README, and frontend client starter to match new security headers/tokens and operational controls.
## Key Changes
- **Route access hardening**
  - Admin required for `GET /api/appointments`, `GET /api/appointments/:id`, `PUT /api/appointments/:id`, `DELETE /api/appointments/:id`, `GET /api/contact`, `DELETE /api/contact/:id`.
  - Public routes intentionally limited to booking/service discovery and contact submission paths.
- **Webhook and payment integrity hardening**
  - Raw-body signature verification for `/api/webhooks/intuit` using `intuit-signature` and `intuit-timestamp`.
  - Replay defenses via timestamp max-age and `WebhookReplayGuard` unique signature hash storage.
  - Payment confirmation checks now enforce strict event allowlist and transaction value/account consistency before status transition.
- **Checkout authorization hardening**
  - Added booking token signing/verification service; `/api/payments/intuit/checkout-session` now requires booking-scoped token.
  - Appointment creation now returns a checkout token (when configured) for secure handoff.
- **Abuse controls and ops baseline**
  - Added Redis-backed limiter support (`REDIS_URL`) with finance/oauth/contact/webhook-specific limiters.
  - Added optional CAPTCHA middleware hook for public create endpoints.
  - Added structured security audit event persistence and security alert email path.
  - Added data-retention cleanup service, scheduler support, and admin run endpoint.
## Database
- Added migration: `20260429143000_security_hardening_foundation`
  - `WebhookReplayGuard`
  - `SecurityAuditEvent`
## Environment Variables Added/Used
- `BOOKING_TOKEN_SECRET`
- `INTUIT_WEBHOOK_MAX_AGE_SECONDS`
- `INTUIT_SUCCESS_EVENT_TYPES` (optional override)
- `REDIS_URL` (for distributed rate limiting)
- `CAPTCHA_SECRET`, `CAPTCHA_PROVIDER`, `CAPTCHA_VERIFY_URL` (optional)
- `SECURITY_ALERT_EMAIL` (optional)
- `ENABLE_DATA_RETENTION_SCHEDULER`, `DATA_RETENTION_INTERVAL_HOURS`
- `RETENTION_CONTACT_REQUEST_DAYS`, `RETENTION_WEBHOOK_EVENT_DAYS`, `RETENTION_SECURITY_AUDIT_DAYS`
## Test plan
- [x] `npm test -- --runInBand src/__tests__/payment.webhook.test.ts src/__tests__/smoke.booking-payment-reminder.test.ts src/__tests__/security.test.ts`
- [x] `npm test -- --runInBand src/__tests__/payment.webhook.test.ts src/__tests__/smoke.booking-payment-reminder.test.ts src/__tests__/appointment.test.ts src/__tests__/appointment.email.test.ts src/__tests__/contactRequest.test.ts src/__tests__/security.test.ts`
- [x] `npx prisma migrate deploy`
- [x] `npx prisma generate`
## Notes
- This PR intentionally keeps admin-key auth in place as a transitional backend-safe boundary while introducing booking-token and webhook-signature controls needed before frontend auth/session rollout.
